### PR TITLE
Port to MRPT 3.x

### DIFF
--- a/mrpt_path_planning_apps/CMakeLists.txt
+++ b/mrpt_path_planning_apps/CMakeLists.txt
@@ -31,9 +31,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # installed first by colcon), plus GUI/simulator libs that mrpt_path_planning_core
 # deliberately does not depend on.
 find_package(mrpt_path_planning REQUIRED)
-find_package(mrpt-gui REQUIRED)
-find_package(mrpt-nav REQUIRED)
-find_package(mrpt-tclap REQUIRED)
+find_package(mrpt_gui REQUIRED)
+find_package(mrpt_nav REQUIRED)
+find_package(CLI11 REQUIRED)
 
 # mvsim is optional: selfdriving-simulator-gui silently skips itself if absent.
 find_package(mvsim-simulator QUIET)

--- a/mrpt_path_planning_apps/mrpt_path_planning_viz/CMakeLists.txt
+++ b/mrpt_path_planning_apps/mrpt_path_planning_viz/CMakeLists.txt
@@ -11,9 +11,9 @@ selfdriving_add_library(
 		include/mpp/algos/viz.h
 		src/algos/viz.cpp
 	PUBLIC_LINK_LIBRARIES
-		mrpt::gui
+		mrpt::mrpt_gui
 		mpp::mrpt_path_planning
 	CMAKE_DEPENDENCIES
-		mrpt-gui
+		mrpt_gui
 		mrpt_path_planning
 )

--- a/mrpt_path_planning_apps/mrpt_path_planning_viz/src/algos/viz.cpp
+++ b/mrpt_path_planning_apps/mrpt_path_planning_viz/src/algos/viz.cpp
@@ -4,23 +4,22 @@
  * See LICENSE for license information.
  * ------------------------------------------------------------------------- */
 
-#include <mpp/algos/viz.h>
-
 #include <mpp/algos/render_tree.h>
 #include <mpp/algos/trajectories.h>
+#include <mpp/algos/viz.h>
 #include <mrpt/gui/CDisplayWindow3D.h>
 #include <mrpt/math/TLine3D.h>
 #include <mrpt/math/TObject3D.h>
 #include <mrpt/math/TPlane.h>
 #include <mrpt/math/geometry.h>
-#include <mrpt/opengl/CCylinder.h>
-#include <mrpt/opengl/CGridPlaneXY.h>
-#include <mrpt/opengl/COpenGLScene.h>
-#include <mrpt/opengl/CSetOfLines.h>
-#include <mrpt/opengl/CSetOfObjects.h>
-#include <mrpt/opengl/stock_objects.h>
 #include <mrpt/poses/CPose2DInterpolator.h>
 #include <mrpt/system/CTicTac.h>
+#include <mrpt/viz/CCylinder.h>
+#include <mrpt/viz/CGridPlaneXY.h>
+#include <mrpt/viz/CSetOfLines.h>
+#include <mrpt/viz/CSetOfObjects.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/stock_objects.h>
 
 #include <thread>
 
@@ -46,22 +45,19 @@ void updateMouseCoordinatesTextMessage(mrpt::gui::CDisplayWindow3D& win)
     win.sendFunctionToRunOnGUIThread(
         [&win]()
         {
-            int mouseX = 0;
-            int mouseY = 0;
-            if (!win.getLastMousePosition(mouseX, mouseY)) return;
+            const auto mousePos = win.getLastMousePosition();
+            if (!mousePos.has_value()) return;
 
-            mrpt::opengl::COpenGLScene::Ptr scene;
-            mrpt::math::TLine3D             mouseRay;
-            bool                            validRay = false;
+            mrpt::viz::Scene::Ptr              scene;
+            std::optional<mrpt::math::TLine3D> mouseRay;
             {
                 mrpt::gui::CDisplayWindow3DLocker dwl(win, scene);
                 if (auto vp = scene->getViewport("main"); vp)
                 {
-                    vp->get3DRayForPixelCoord(mouseX, mouseY, mouseRay);
-                    validRay = true;
+                    mouseRay = vp->get3DRayForPixelCoord(*mousePos);
                 }
             }
-            if (!validRay) return;
+            if (!mouseRay.has_value()) return;
 
             // Intersection of the mouse ray with the ground plane Z=0:
             using mrpt::math::TPoint3D;
@@ -69,7 +65,7 @@ void updateMouseCoordinatesTextMessage(mrpt::gui::CDisplayWindow3D& win)
                 TPoint3D(0, 0, 0), TPoint3D(1, 0, 0), TPoint3D(0, 1, 0));
 
             mrpt::math::TObject3D inters;
-            mrpt::math::intersect(mouseRay, groundPlane, inters);
+            mrpt::math::intersect(*mouseRay, groundPlane, inters);
 
             mrpt::math::TPoint3D pt;
             if (!inters.getPoint(pt)) return;
@@ -103,14 +99,11 @@ void mpp::viz_nav_plan(
         {
             nonmodal_win = mrpt::gui::CDisplayWindow3D::Create(title, 800, 600);
         }
-        else
-        {
-            nonmodal_win->setWindowTitle(title);
-        }
+        else { nonmodal_win->setWindowTitle(title); }
         win = nonmodal_win;
     }
 
-    mrpt::opengl::COpenGLScene::Ptr scene;
+    mrpt::viz::Scene::Ptr scene;
 
     // Build opengl scene (replacing any previous contents, if this window is
     // being reused across calls):
@@ -132,7 +125,7 @@ void mpp::viz_nav_plan(
     // Camera:
     win->setCameraAzimuthDeg(-90);
     win->setCameraElevationDeg(90);
-    win->setCameraProjective(false);
+    win->setProjectiveModel(false);
 
     // Look at path start:
     const auto& start = plan.originalInput.stateStart.pose;
@@ -182,17 +175,17 @@ void mpp::viz_nav_plan_animation(
     // Create UI:
     auto win = mrpt::gui::CDisplayWindow3D::Create("Path plan viz", 800, 600);
 
-    mrpt::opengl::COpenGLScene::Ptr scene;
+    mrpt::viz::Scene::Ptr scene;
 
-    auto glVehFrame = mrpt::opengl::CSetOfObjects::Create();
-    auto glVeh      = mrpt::opengl::CSetOfObjects::Create();
+    auto glVehFrame = mrpt::viz::CSetOfObjects::Create();
+    auto glVeh      = mrpt::viz::CSetOfObjects::Create();
 
-    auto glRobotShape = mrpt::opengl::CSetOfLines::Create();
+    auto glRobotShape = mrpt::viz::CSetOfLines::Create();
     plan.originalInput.ptgs.ptgs.front()->add_robotShape_to_setOfLines(
         *glRobotShape);
     glRobotShape->setColor_u8(0xff, 0x00, 0x00, 0xff);  // RGB+A
     glVeh->insert(glRobotShape);
-    auto glVehCorner = mrpt::opengl::stock_objects::CornerXYZ(0.3);
+    auto glVehCorner = mrpt::viz::stock_objects::CornerXYZ(0.3);
     glVeh->insert(glVehCorner);
 
     glVehFrame->insert(glVeh);
@@ -215,7 +208,7 @@ void mpp::viz_nav_plan_animation(
     // Camera:
     win->setCameraAzimuthDeg(-90);
     win->setCameraElevationDeg(90);
-    win->setCameraProjective(false);
+    win->setProjectiveModel(false);
     // Look at path start:
     const auto& start = plan.originalInput.stateStart.pose;
     win->setCameraPointingToPoint(start.x, start.y, .0f);

--- a/mrpt_path_planning_apps/package.xml
+++ b/mrpt_path_planning_apps/package.xml
@@ -17,9 +17,9 @@
 
   <!-- Deps required by user code (they are in public headers or built as ROS (vs system) packages -->
   <depend>mrpt_path_planning_core</depend>
-  <depend>mrpt_libgui</depend>
-  <depend>mrpt_libnav</depend>
-  <depend>mrpt_libtclap</depend>
+  <depend>mrpt_gui</depend>
+  <depend>mrpt_nav</depend>
+  <depend>cli11</depend>
   <depend>mvsim</depend>
 
   <!-- Minimum entries to release non-catkin pkgs: -->

--- a/mrpt_path_planning_apps/path-planner-cli/CMakeLists.txt
+++ b/mrpt_path_planning_apps/path-planner-cli/CMakeLists.txt
@@ -1,16 +1,18 @@
 project(path-planner-cli LANGUAGES CXX)
 
 # find dependencies:
-find_package(MRPT REQUIRED COMPONENTS gui nav tclap)
+find_package(mrpt_gui REQUIRED)
+find_package(mrpt_nav REQUIRED)
+find_package(CLI11 REQUIRED)
 
 selfdriving_add_executable(
   TARGET ${PROJECT_NAME}
   SOURCES
     path-planner-cli.cpp
 	LINK_LIBRARIES
-    mrpt::gui
-    mrpt::nav
-    mrpt::tclap
+    mrpt::mrpt_gui
+    mrpt::mrpt_nav
+    CLI11::CLI11
     mpp::mrpt_path_planning
     mrpt_path_planning_viz
 )

--- a/mrpt_path_planning_apps/path-planner-cli/path-planner-cli.cpp
+++ b/mrpt_path_planning_apps/path-planner-cli/path-planner-cli.cpp
@@ -12,7 +12,6 @@
 #include <mpp/algos/viz.h>
 #include <mpp/algos/viz_svg.h>
 #include <mpp/data/Waypoints.h>
-#include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/config/CConfigFile.h>
 #include <mrpt/core/exceptions.h>  // exception_to_str()
 #include <mrpt/io/CFileGZInputStream.h>
@@ -25,156 +24,55 @@
 #include <mrpt/system/os.h>  // plugins
 #include <mrpt/version.h>
 
+#include <CLI/CLI.hpp>
 #include <fstream>
 #include <iostream>
 
-TCLAP::CmdLine cmd("path-planner-cli");
-
-TCLAP::ValueArg<std::string> arg_obs_file(
-    "o", "obstacles",
-    "Input obstacles: either (1) a .txt file with obstacle points (one 'x y' "
-    "pair per line), or (2) a .gridmap file, or (3) a ROS MAP YAML file, or a "
-    "(4) png file with an gray-scale occupancy grid (*.png, *.bmp)",
-    true, "", "obs.txt", cmd);
-
-TCLAP::ValueArg<std::string> argPlanner(
-    "p", "planner", "Planner C++ class name to use", false, "mpp::TPS_Astar",
-    "mpp::TPS_Astar", cmd);
-
-TCLAP::ValueArg<std::string> argVerbosity(
-    "v", "verbose", "Verbosity level for path planner", false, "INFO",
-    "ERROR|WARN|INFO|DEBUG", cmd);
-
-TCLAP::ValueArg<float> argObstaclesGridResolution(
-    "", "obstacles-gridimage-resolution",
-    "Only if --obstacles points to an image file, this sets the length of each "
-    "pixel in meters.",
-    false, 0.05, "0.05", cmd);
-
-TCLAP::ValueArg<float> arg_interpolation_period(
-    "", "interpolarion-period",
-    "Interpolation (and animation) time step between keyframes [s].", false,
-    0.25, "0.25", cmd);
-
-TCLAP::ValueArg<std::string> arg_ptgs_file(
-    "c", "ptg-config", "Input .ini file with PTG definitions.", true, "",
-    "ptgs.ini", cmd);
-
-TCLAP::ValueArg<std::string> argPlanner_yaml_file(
-    "", "planner-parameters", "Input .yaml file with planner parameters", false,
-    "", "tps-astar.yaml", cmd);
-
-TCLAP::ValueArg<std::string> argPlanner_yaml_output_file(
-    "", "write-planner-parameters",
-    "If defined, it will save default planner params to a .yaml file and exit.",
-    false, "", "tps-astar.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_config_file_section(
-    "", "config-section",
-    "If loading from an INI file, the name of the section to load", false,
-    "SelfDriving", "SelfDriving", cmd);
-
-TCLAP::ValueArg<std::string> arg_start_pose(
-    "s", "start-pose", "Start 2D pose", true, "", "\"[x y phi_deg]\"", cmd);
-
-TCLAP::ValueArg<std::string> arg_start_vel(
-    "", "start-vel", "Start 2D velocity", false, "[0 0 0]",
-    "\"[vx vy omega_deg]\"", cmd);
-
-TCLAP::ValueArg<std::string> arg_goal_pose(
-    "g", "goal-pose", "Goal 2D pose or point", true, "[0 0 0]",
-    "\"[x y phi_deg]\" or \"[x y]\"", cmd);
-
-TCLAP::ValueArg<double> argBBoxMargin(
-    "", "bbox-margin", "Margin to add to the start-goal bbox poses", false, 2.0,
-    "A distance [meters]", cmd);
-
-TCLAP::ValueArg<std::string> arg_goal_vel(
-    "", "goal-vel", "Goal 2D velocity", false, "", "\"[vx vy omega_deg]\"",
-    cmd);
-
-TCLAP::ValueArg<unsigned int> argRandomSeed(
-    "", "random-seed", "Pseudorandom generator seed (default: from time)",
-    false, 0, "0", cmd);
-
-TCLAP::ValueArg<std::string> arg_plugins(
-    "", "plugins",
-    "Optional plug-in libraries to load, for externally-defined PTGs", false,
-    "", "mylib.so", cmd);
-
-TCLAP::ValueArg<std::string> arg_costMap(
-    "", "costmap-obstacles",
-    "Creates a costmap from obstacle point clouds with the given parameters "
-    "from a YAML file.",
-    false, "costmap.yaml", "costmap.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_waypoints(
-    "", "waypoints",
-    "This creates a preferred-waypoints costlayer, from the waypoint list in a "
-    "given YAML file.",
-    false, "waypoints.yaml", "waypoints.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_waypointsParams(
-    "", "waypoints-parameters",
-    "If --waypoints is also set, this loads the preferred waypoints costlayer "
-    "parameters from a YAML file.",
-    false, "waypoints-parameters.yaml", "waypoints-parameters.yaml", cmd);
-
-TCLAP::SwitchArg arg_showTree(
-    "", "show-tree",
-    "Shows the whole search tree instead of just the best path", cmd);
-
-TCLAP::SwitchArg arg_ignoreObstaclesBbox(
-    "", "ignore-obstacles-bbox",
-    "Ignore obstacles for estimating the problem world bounding box", cmd);
-
-TCLAP::SwitchArg arg_noRefine(
-    "", "no-refine", "Skips the post-plan refine stage", cmd);
-
-TCLAP::SwitchArg arg_showEdgeWeights(
-    "", "show-edge-weights", "Shows the weight of path edges", cmd);
-
-TCLAP::SwitchArg arg_printPathEdges(
-    "", "print-path-edges", "Prints details on the found planned path edges",
-    cmd);
-
-TCLAP::ValueArg<std::string> arg_InterpolatePath(
-    "", "save-interpolated-path",
-    "Interpolates the path and saves it into a .csv file", false, "path.csv",
-    "path.csv", cmd);
-
-TCLAP::ValueArg<std::string> arg_save_svg(
-    "", "save-svg",
-    "Saves a 2D SVG plot of the plan (obstacles, tree, path, robot shapes) for "
-    "debugging / paper figures",
-    false, "", "plan.svg", cmd);
-
-TCLAP::SwitchArg arg_playAnimation(
-    "", "play-animation",
-    "Shows the GUI with an animation of the vehicle moving along the path",
-    cmd);
-
-TCLAP::SwitchArg arg_noGui(
-    "", "no-gui",
-    "Do not open any GUI window (for headless/batch use, e.g. mass figure "
-    "export). The process exits without waiting for a window to be closed.",
-    cmd);
-
-TCLAP::ValueArg<size_t> arg_svg_tree_decimation(
-    "", "svg-tree-decimation",
-    "When exporting SVG, draw only one motion-tree edge out of every N. Use a "
-    "larger value to thin out very dense (e.g. failed-query) trees.",
-    false, 1, "1", cmd);
-
-TCLAP::SwitchArg arg_svg_no_tree(
-    "", "svg-no-tree", "When exporting SVG, omit the motion tree entirely.",
-    cmd);
+// CLI globals (populated in main before helper functions are called):
+static std::string  arg_obs_file;
+static std::string  argPlanner{"mpp::TPS_Astar"};
+static std::string  argVerbosity{"INFO"};
+static float        argObstaclesGridResolution{0.05f};
+static float        arg_interpolation_period{0.25f};
+static std::string  arg_ptgs_file;
+static std::string  argPlanner_yaml_file;
+static std::string  argPlanner_yaml_output_file;
+static std::string  arg_config_file_section{"SelfDriving"};
+static std::string  arg_start_pose;
+static std::string  arg_start_vel{"[0 0 0]"};
+static bool         arg_start_vel_set{false};
+static std::string  arg_goal_pose{"[0 0 0]"};
+static double       argBBoxMargin{2.0};
+static std::string  arg_goal_vel;
+static bool         arg_goal_vel_set{false};
+static unsigned int argRandomSeed{0};
+static bool         argRandomSeed_set{false};
+static std::string  arg_plugins;
+static std::string  arg_costMap;
+static bool         arg_costMap_set{false};
+static std::string  arg_waypoints;
+static bool         arg_waypoints_set{false};
+static std::string  arg_waypointsParams;
+static bool         arg_waypointsParams_set{false};
+static bool         arg_showTree{false};
+static bool         arg_ignoreObstaclesBbox{false};
+static bool         arg_noRefine{false};
+static bool         arg_showEdgeWeights{false};
+static bool         arg_printPathEdges{false};
+static std::string  arg_InterpolatePath;
+static bool         arg_InterpolatePath_set{false};
+static std::string  arg_save_svg;
+static bool         arg_save_svg_set{false};
+static bool         arg_playAnimation{false};
+static bool         arg_noGui{false};
+static size_t       arg_svg_tree_decimation{1};
+static bool         arg_svg_no_tree{false};
 
 static mrpt::maps::CPointsMap::Ptr load_obstacles()
 {
     auto obsPts = mrpt::maps::CSimplePointsMap::Create();
 
-    const auto sFile = arg_obs_file.getValue();
+    const auto& sFile = arg_obs_file;
     ASSERT_FILE_EXISTS_(sFile);
 
     const auto sExt =
@@ -184,9 +82,11 @@ static mrpt::maps::CPointsMap::Ptr load_obstacles()
         mrpt::system::strCmpI(sExt, "pts"))
     {
         if (!obsPts->load2D_from_text_file(sFile))
+        {
             THROW_EXCEPTION_FMT(
                 "Cannot read obstacle point cloud from: `%s`",
-                arg_obs_file.getValue().c_str());
+                arg_obs_file.c_str());
+        }
     }
     else if (mrpt::system::strCmpI(sExt, "yaml"))
     {
@@ -213,7 +113,7 @@ static mrpt::maps::CPointsMap::Ptr load_obstacles()
         mrpt::system::strCmpI(sExt, "bmp"))
     {
         mrpt::maps::COccupancyGridMap2D grid;
-        grid.loadFromBitmapFile(sFile, argObstaclesGridResolution.getValue());
+        grid.loadFromBitmapFile(sFile, argObstaclesGridResolution);
         grid.getAsPointCloud(*obsPts);
     }
 
@@ -229,22 +129,17 @@ static void do_plan_path()
     // Prepare planner input data:
     mpp::PlannerInput pi;
 
-    pi.stateStart.pose.fromString(arg_start_pose.getValue());
-    if (arg_start_vel.isSet())
-        pi.stateStart.vel.fromString(arg_start_vel.getValue());
+    pi.stateStart.pose.fromString(arg_start_pose);
+    if (arg_start_vel_set) { pi.stateStart.vel.fromString(arg_start_vel); }
 
-    pi.stateGoal.state = mpp::PoseOrPoint::FromString(arg_goal_pose.getValue());
-    if (arg_goal_vel.isSet())
-        pi.stateGoal.vel.fromString(arg_goal_vel.getValue());
+    pi.stateGoal.state = mpp::PoseOrPoint::FromString(arg_goal_pose);
+    if (arg_goal_vel_set) { pi.stateGoal.vel.fromString(arg_goal_vel); }
 
     pi.obstacles.emplace_back(obs);
 
     mrpt::math::TBoundingBoxf bbox;
 
-    if (!arg_ignoreObstaclesBbox.isSet())
-    {
-        bbox = obs->obstacles()->boundingBox();
-    }
+    if (!arg_ignoreObstaclesBbox) { bbox = obs->obstacles()->boundingBox(); }
     else
     {
         // This will ensure the next updateWithPoint() will set the bbox:
@@ -253,8 +148,8 @@ static void do_plan_path()
 
     // Make sure goal and start are within bbox:
     {
-        const auto bboxMargin = mrpt::math::TPoint3Df(
-            argBBoxMargin.getValue(), argBBoxMargin.getValue(), .0);
+        const auto bboxMargin =
+            mrpt::math::TPoint3Df(argBBoxMargin, argBBoxMargin, .0);
         const auto ptStart = mrpt::math::TPoint3Df(
             pi.stateStart.pose.x, pi.stateStart.pose.y, 0);
         const auto ptGoal = mrpt::math::TPoint3Df(
@@ -275,16 +170,16 @@ static void do_plan_path()
     std::cout << "World bbox : " << pi.worldBboxMin.asString() << " - "
               << pi.worldBboxMax.asString() << "\n";
 
-    // Do the path planning :
+    // Do the path planning:
     mpp::Planner::Ptr planner = std::dynamic_pointer_cast<mpp::Planner>(
-        mrpt::rtti::classFactory(argPlanner.getValue()));
+        mrpt::rtti::classFactory(argPlanner));
 
     if (!planner)
     {
         THROW_EXCEPTION_FMT(
             "Given classname '%s' does not seem to be a known C++ class "
             "implementing `Planner",
-            argPlanner.getValue().c_str());
+            argPlanner.c_str());
     }
 
     // Enable time profiler:
@@ -294,17 +189,17 @@ static void do_plan_path()
     // available to make the costmap footprint-aware):
     std::cout << "[PTGs] Initializing PTGs..." << std::endl;
 
-    mrpt::config::CConfigFile cfg(arg_ptgs_file.getValue());
-    pi.ptgs.initFromConfigFile(cfg, arg_config_file_section.getValue());
+    mrpt::config::CConfigFile cfg(arg_ptgs_file);
+    pi.ptgs.initFromConfigFile(cfg, arg_config_file_section);
 
     std::cout << "[PTGs] Done." << std::endl;
 
-    if (arg_costMap.isSet())
+    if (arg_costMap_set)
     {
         // cost map:
         const auto costMapParams =
             mpp::CostEvaluatorCostMap::Parameters::FromYAML(
-                mrpt::containers::yaml::FromFile(arg_costMap.getValue()));
+                mrpt::containers::yaml::FromFile(arg_costMap));
 
         auto costmap = mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
             *obsPts, costMapParams, pi.stateStart.pose, pi.ptgs.robotShape);
@@ -314,19 +209,19 @@ static void do_plan_path()
 
     // Preferred waypoints:
     auto wpParams = mpp::CostEvaluatorPreferredWaypoint::Parameters();
-    if (arg_waypointsParams.isSet())
+    if (arg_waypointsParams_set)
     {
         wpParams = mpp::CostEvaluatorPreferredWaypoint::Parameters::FromYAML(
-            mrpt::containers::yaml::FromFile(arg_waypointsParams.getValue()));
+            mrpt::containers::yaml::FromFile(arg_waypointsParams));
     }
 
-    if (arg_waypoints.isSet())
+    if (arg_waypoints_set)
     {
         const auto wps = mpp::WaypointSequence::FromYAML(
-            mrpt::containers::yaml::FromFile(arg_waypoints.getValue()));
+            mrpt::containers::yaml::FromFile(arg_waypoints));
 
         std::vector<mrpt::math::TPoint2D> lstPts;
-        for (const auto& wp : wps.waypoints) lstPts.emplace_back(wp.target);
+        for (const auto& wp : wps.waypoints) { lstPts.emplace_back(wp.target); }
 
         auto costEval     = mpp::CostEvaluatorPreferredWaypoint::Create();
         costEval->params_ = wpParams;
@@ -337,12 +232,12 @@ static void do_plan_path()
     // verbosity level:
     planner->setMinLoggingLevel(
         mrpt::typemeta::TEnumType<mrpt::system::VerbosityLevel>::name2value(
-            argVerbosity.getValue()));
+            argVerbosity));
 
     // Set planner required params:
-    if (argPlanner_yaml_file.isSet())
+    if (!argPlanner_yaml_file.empty())
     {
-        const auto sFile = argPlanner_yaml_file.getValue();
+        const auto& sFile = argPlanner_yaml_file;
         ASSERT_FILE_EXISTS_(sFile);
         const auto c = mrpt::containers::yaml::FromFile(sFile);
         planner->params_from_yaml(c);
@@ -370,16 +265,16 @@ static void do_plan_path()
               << " overall edges, " << plan.motionTree.nodes().size()
               << " nodes\n";
 
-    if (arg_save_svg.isSet())
+    if (arg_save_svg_set)
     {
         mpp::SvgExportOptions svgOpts;
-        svgOpts.draw_tree      = !arg_svg_no_tree.isSet();
-        svgOpts.tree_decimation = arg_svg_tree_decimation.getValue();
-        if (mpp::save_plan_to_svg(plan, arg_save_svg.getValue(), svgOpts))
-            std::cout << "Saved SVG plot: " << arg_save_svg.getValue() << "\n";
-        else
-            std::cerr << "Could not write SVG: " << arg_save_svg.getValue()
-                      << "\n";
+        svgOpts.draw_tree       = !arg_svg_no_tree;
+        svgOpts.tree_decimation = arg_svg_tree_decimation;
+        if (mpp::save_plan_to_svg(plan, arg_save_svg, svgOpts))
+        {
+            std::cout << "Saved SVG plot: " << arg_save_svg << "\n";
+        }
+        else { std::cerr << "Could not write SVG: " << arg_save_svg << "\n"; }
     }
 
     if (!plan.bestNodeId.has_value())
@@ -392,7 +287,7 @@ static void do_plan_path()
     auto [plannedPath, pathEdges] =
         plan.motionTree.backtrack_path(*plan.bestNodeId);
 
-    if (!arg_noRefine.isSet())
+    if (!arg_noRefine)
     {
         // refine:
         mpp::refine_trajectory(plannedPath, pathEdges, pi.ptgs);
@@ -404,28 +299,31 @@ static void do_plan_path()
     vizOpts.renderOptions.highlight_path_to_node_id = plan.bestNodeId;
     vizOpts.renderOptions.color_normal_edge         = {0xb0b0b0, 0x20};  // RGBA
 
-    vizOpts.renderOptions.showEdgeCosts = arg_showEdgeWeights.isSet();
+    vizOpts.renderOptions.showEdgeCosts = arg_showEdgeWeights;
 
     // Hide regular tree edges and only show best path?
-    if (!arg_showTree.isSet()) vizOpts.renderOptions.width_normal_edge = 0;
+    if (!arg_showTree) { vizOpts.renderOptions.width_normal_edge = 0; }
 
     std::optional<mpp::trajectory_t> traj;  // interpolated path
 
     if (plan.success)
     {
         // generate path sequence:
-        if (arg_printPathEdges.isSet())
+        if (arg_printPathEdges)
         {
             std::cout << "Planned path edges:\n";
-            for (const auto& edge : pathEdges) std::cout << edge->asString();
+            for (const auto& edge : pathEdges)
+            {
+                std::cout << edge->asString();
+            }
         }
 
         // interpolate path:
-        if (arg_InterpolatePath.isSet() || arg_playAnimation.isSet())
+        if (arg_InterpolatePath_set || arg_playAnimation)
         {
             const auto t0 = mrpt::Clock::nowDouble();
 
-            const double interpPeriod = arg_interpolation_period.getValue();
+            const double interpPeriod = arg_interpolation_period;
 
             traj = mpp::plan_to_trajectory(pathEdges, pi.ptgs, interpPeriod);
 
@@ -435,25 +333,27 @@ static void do_plan_path()
             // frame:
             const auto& startPose = plan.originalInput.stateStart.pose;
             for (auto& kv : *traj)
+            {
                 kv.second.state.pose = startPose + kv.second.state.pose;
+            }
 
             const auto dt = mrpt::Clock::nowDouble() - t0;
 
             std::cout << "Interpolated path done in "
                       << mrpt::system::intervalFormat(dt) << ".\n";
 
-            if (arg_InterpolatePath.isSet())
+            if (arg_InterpolatePath_set)
             {
-                std::cout << "Saving path to " << arg_InterpolatePath.getValue()
+                std::cout << "Saving path to " << arg_InterpolatePath
                           << std::endl;
-                mpp::save_to_txt(*traj, arg_InterpolatePath.getValue());
+                mpp::save_to_txt(*traj, arg_InterpolatePath);
             }
         }
     }
 
     // GUI (skipped entirely in headless/batch mode):
-    if (arg_noGui.isSet()) return;
-    if (!arg_playAnimation.isSet() || !traj.has_value())
+    if (arg_noGui) return;
+    if (!arg_playAnimation || !traj.has_value())
     {
         // regular UI:
         mpp::viz_nav_plan(plan, vizOpts, planner->costEvaluators_);
@@ -470,37 +370,150 @@ int main(int argc, char** argv)
 {
     try
     {
-        bool cmdsOk = cmd.parse(argc, argv);
+        CLI::App app{"path-planner-cli"};
 
-        if (argPlanner_yaml_output_file.isSet())
+        app.add_option(
+               "-o,--obstacles", arg_obs_file,
+               "Input obstacles: either (1) a .txt file with obstacle points "
+               "(one 'x y' "
+               "pair per line), or (2) a .gridmap file, or (3) a ROS MAP YAML "
+               "file, or a "
+               "(4) png file with an gray-scale occupancy grid (*.png, *.bmp)")
+            ->required();
+        app.add_option(
+            "-p,--planner", argPlanner, "Planner C++ class name to use.");
+        app.add_option(
+            "-v,--verbose", argVerbosity, "Verbosity level for path planner.");
+        app.add_option(
+            "--obstacles-gridimage-resolution", argObstaclesGridResolution,
+            "Only if --obstacles points to an image file, this sets the length "
+            "of each pixel in "
+            "meters.");
+        app.add_option(
+            "--interpolarion-period", arg_interpolation_period,
+            "Interpolation (and animation) time step between keyframes [s].");
+        app.add_option(
+               "-c,--ptg-config", arg_ptgs_file,
+               "Input .ini file with PTG definitions.")
+            ->required();
+        app.add_option(
+            "--planner-parameters", argPlanner_yaml_file,
+            "Input .yaml file with planner parameters.");
+        app.add_option(
+            "--write-planner-parameters", argPlanner_yaml_output_file,
+            "If defined, it will save default planner params to a .yaml file "
+            "and exit.");
+        app.add_option(
+            "--config-section", arg_config_file_section,
+            "If loading from an INI file, the name of the section to load.");
+        app.add_option("-s,--start-pose", arg_start_pose, "Start 2D pose.")
+            ->required();
+        app.add_option("--start-vel", arg_start_vel, "Start 2D velocity.");
+        app.add_option(
+            "-g,--goal-pose", arg_goal_pose, "Goal 2D pose or point.");
+        app.add_option(
+            "--bbox-margin", argBBoxMargin,
+            "Margin to add to the start-goal bbox poses.");
+        app.add_option("--goal-vel", arg_goal_vel, "Goal 2D velocity.");
+        app.add_option(
+            "--random-seed", argRandomSeed,
+            "Pseudorandom generator seed (default: from time).");
+        app.add_option(
+            "--plugins", arg_plugins,
+            "Optional plug-in libraries to load, for externally-defined PTGs.");
+        app.add_option(
+            "--costmap-obstacles", arg_costMap,
+            "Creates a costmap from obstacle point clouds with the given "
+            "parameters from a YAML "
+            "file.");
+        app.add_option(
+            "--waypoints", arg_waypoints,
+            "This creates a preferred-waypoints costlayer, from the waypoint "
+            "list in a given "
+            "YAML file.");
+        app.add_option(
+            "--waypoints-parameters", arg_waypointsParams,
+            "If --waypoints is also set, this loads the preferred waypoints "
+            "costlayer "
+            "parameters from a YAML file.");
+        app.add_flag(
+            "--show-tree", arg_showTree,
+            "Shows the whole search tree instead of just the best path.");
+        app.add_flag(
+            "--ignore-obstacles-bbox", arg_ignoreObstaclesBbox,
+            "Ignore obstacles for estimating the problem world bounding box.");
+        app.add_flag(
+            "--no-refine", arg_noRefine, "Skips the post-plan refine stage.");
+        app.add_flag(
+            "--show-edge-weights", arg_showEdgeWeights,
+            "Shows the weight of path edges.");
+        app.add_flag(
+            "--print-path-edges", arg_printPathEdges,
+            "Prints details on the found planned path edges.");
+        app.add_option(
+            "--save-interpolated-path", arg_InterpolatePath,
+            "Interpolates the path and saves it into a .csv file.");
+        app.add_option(
+            "--save-svg", arg_save_svg,
+            "Saves a 2D SVG plot of the plan (obstacles, tree, path, robot "
+            "shapes) for "
+            "debugging / paper figures.");
+        app.add_flag(
+            "--play-animation", arg_playAnimation,
+            "Shows the GUI with an animation of the vehicle moving along the "
+            "path.");
+        app.add_flag(
+            "--no-gui", arg_noGui,
+            "Do not open any GUI window (for headless/batch use, e.g. mass "
+            "figure "
+            "export). The process exits without waiting for a window to be "
+            "closed.");
+        app.add_option(
+            "--svg-tree-decimation", arg_svg_tree_decimation,
+            "When exporting SVG, draw only one motion-tree edge out of every "
+            "N. Use a "
+            "larger value to thin out very dense (e.g. failed-query) trees.");
+        app.add_flag(
+            "--svg-no-tree", arg_svg_no_tree,
+            "When exporting SVG, omit the motion tree entirely.");
+
+        CLI11_PARSE(app, argc, argv);
+
+        // Detect which optional string options were actually provided:
+        arg_start_vel_set       = (app.count("--start-vel") > 0);
+        arg_goal_vel_set        = (app.count("--goal-vel") > 0);
+        argRandomSeed_set       = (app.count("--random-seed") > 0);
+        arg_costMap_set         = (app.count("--costmap-obstacles") > 0);
+        arg_waypoints_set       = (app.count("--waypoints") > 0);
+        arg_waypointsParams_set = (app.count("--waypoints-parameters") > 0);
+        arg_InterpolatePath_set = (app.count("--save-interpolated-path") > 0);
+        arg_save_svg_set        = (app.count("--save-svg") > 0);
+
+        if (!argPlanner_yaml_output_file.empty())
         {
             mpp::TPS_Astar_Parameters defaults;
-            const auto                c = defaults.as_yaml();
-            const auto    sFile = argPlanner_yaml_output_file.getValue();
-            std::ofstream fileYaml(sFile);
+            const auto                c     = defaults.as_yaml();
+            const auto&               sFile = argPlanner_yaml_output_file;
+            std::ofstream             fileYaml(sFile);
             ASSERT_(fileYaml.is_open());
             c.printAsYAML(fileYaml);
             std::cout << "Wrote file: " << sFile << std::endl;
             return 0;
         }
 
-        if (!cmdsOk) return 1;
-
-        if (arg_plugins.isSet())
+        if (!arg_plugins.empty())
         {
             std::string loadErrors;
-            if (!mrpt::system::loadPluginModules(
-                    arg_plugins.getValue(), loadErrors))
+            if (!mrpt::system::loadPluginModules(arg_plugins, loadErrors))
             {
                 std::cerr << "Could not load plugins, error: " << loadErrors;
                 return 1;
             }
         }
 
-        if (argRandomSeed.isSet())
+        if (argRandomSeed_set)
         {
-            mrpt::random::getRandomGenerator().randomize(
-                argRandomSeed.getValue());
+            mrpt::random::getRandomGenerator().randomize(argRandomSeed);
         }
 
         do_plan_path();

--- a/mrpt_path_planning_apps/selfdriving-simulator-gui/CMakeLists.txt
+++ b/mrpt_path_planning_apps/selfdriving-simulator-gui/CMakeLists.txt
@@ -11,7 +11,7 @@ selfdriving_add_executable(
     selfdriving-simulator-gui.cpp
     MVSIM_VehicleInterface.h
   LINK_LIBRARIES
-    mrpt::tclap
+    CLI11::CLI11
     mpp::mrpt_path_planning
     mvsim::mvsim-simulator
     mvsim::mvsim-comms

--- a/mrpt_path_planning_apps/selfdriving-simulator-gui/selfdriving-simulator-gui.cpp
+++ b/mrpt_path_planning_apps/selfdriving-simulator-gui/selfdriving-simulator-gui.cpp
@@ -9,27 +9,28 @@
 #include <mpp/algos/NavEngine.h>
 #include <mpp/algos/TPS_Astar.h>
 #include <mpp/data/Waypoints.h>
-#include "MVSIM_VehicleInterface.h"
 #include <mpp/interfaces/VehicleMotionInterface.h>
-#include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/config/CConfigFile.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/core/lock_helper.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/math/TLine3D.h>
 #include <mrpt/math/TObject3D.h>
-#include <mrpt/opengl/CDisk.h>
 #include <mrpt/system/CRateTimer.h>
 #include <mrpt/system/os.h>  // plugins
 #include <mrpt/version.h>
+#include <mrpt/viz/CDisk.h>
 #include <mvsim/Comms/Server.h>
 #include <mvsim/World.h>
 #include <mvsim/WorldElements/OccupancyGridMap.h>
 #include <mvsim/WorldElements/PointCloud.h>
 #include <mvsim/mvsim_version.h>
 
+#include <CLI/CLI.hpp>
 #include <thread>
 #include <type_traits>
+
+#include "MVSIM_VehicleInterface.h"
 namespace compat
 {
 // 1. Primary template: The "Fallback" branch
@@ -52,73 +53,31 @@ struct gui_event_picker<T, std::void_t<typename T::GUIKeyEvent>>
 using GUIKeyEvent = typename gui_event_picker<mvsim::World>::type;
 }  // namespace compat
 
-TCLAP::CmdLine cmd(
-    "selfdriving-simulator-gui", ' ', "version", false /* no --help */);
+static CLI::App app{"selfdriving-simulator-gui"};
 
-TCLAP::ValueArg<std::string> argVerbosity(
-    "v", "verbose", "Verbosity level for path planner", false, "INFO",
-    "ERROR|WARN|INFO|DEBUG", cmd);
-
-TCLAP::ValueArg<std::string> argVerbosityMVSIM(
-    "", "verbose-mvsim", "Verbosity level for the mvsim subsystem", false,
-    "INFO", "ERROR|WARN|INFO|DEBUG", cmd);
-
-TCLAP::ValueArg<std::string> arg_config_file_section(
-    "", "config-section",
-    "If loading from an INI file, the name of the section to load", false,
-    "SelfDriving", "SelfDriving", cmd);
-
-TCLAP::ValueArg<std::string> argMvsimFile(
-    "s", "simul-file", "MVSIM XML file", true, "xxx.xml", "World XML file",
-    cmd);
-
-TCLAP::ValueArg<std::string> argVehicleInterface(
-    "", "vehicle-interface-class",
-    "Class name to use (Default: 'mpp::MVSIM_VehicleInterface')", false,
-    "mpp::MVSIM_VehicleInterface", "Class name to use for vehicle interface",
-    cmd);
-
-TCLAP::ValueArg<std::string> argTargetApproachController(
-    "", "approach-controller-class",
-    "Class name to use as target approach controller (Default: none)", false,
-    "", "Class name to use for approach controller", cmd);
-
-TCLAP::ValueArg<std::string> arg_ptgs_file(
-    "p", "ptg-config", "Input .ini file with PTG definitions.", true, "",
-    "ptgs.ini", cmd);
-
-TCLAP::ValueArg<std::string> arg_planner_yaml_file(
-    "", "planner-parameters", "Input .yaml file with planner parameters", false,
-    "", "tps-astar.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_cost_prefer_waypoints_yaml_file(
-    "", "prefer-waypoints-parameters",
-    "Input .yaml file with costmap parameters", false, "",
-    "cost-prefer-waypoints.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_cost_global_yaml_file(
-    "", "global-costmap-parameters",
-    "Input .yaml file with global obstacle points costmap parameters", false,
-    "", "points-costmap.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_cost_local_yaml_file(
-    "", "local-costmap-parameters",
-    "Input .yaml file with local obstacle points costmap parameters", false, "",
-    "points-costmap.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_nav_engine_yaml_file(
-    "", "nav-engine-parameters",
-    "Input .yaml file with parameters for NavEngine", false, "",
-    "nav-engine.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_waypoints_yaml_file(
-    "", "waypoints", "Input .yaml file with waypoints", false, "",
-    "waypoints.yaml", cmd);
-
-TCLAP::ValueArg<std::string> arg_plugins(
-    "", "plugins",
-    "Optional plug-in libraries to load, for externally-defined PTGs", false,
-    "", "mylib.so", cmd);
+static std::string argVerbosity{"INFO"};
+static std::string argVerbosityMVSIM{"INFO"};
+static std::string arg_config_file_section{"SelfDriving"};
+static std::string argMvsimFile;
+static std::string argVehicleInterface{"mpp::MVSIM_VehicleInterface"};
+static bool        argVehicleInterface_set{false};
+static std::string argTargetApproachController;
+static bool        argTargetApproachController_set{false};
+static std::string arg_ptgs_file;
+static std::string arg_planner_yaml_file;
+static bool        arg_planner_yaml_file_set{false};
+static std::string arg_cost_prefer_waypoints_yaml_file;
+static bool        arg_cost_prefer_waypoints_yaml_file_set{false};
+static std::string arg_cost_global_yaml_file;
+static bool        arg_cost_global_yaml_file_set{false};
+static std::string arg_cost_local_yaml_file;
+static bool        arg_cost_local_yaml_file_set{false};
+static std::string arg_nav_engine_yaml_file;
+static bool        arg_nav_engine_yaml_file_set{false};
+static std::string arg_waypoints_yaml_file;
+static bool        arg_waypoints_yaml_file_set{false};
+static std::string arg_plugins;
+static bool        arg_plugins_set{false};
 
 std::shared_ptr<mvsim::Server> server;
 
@@ -131,7 +90,7 @@ void commonLaunchServer()
 
     server->setMinLoggingLevel(
         mrpt::typemeta::TEnumType<mrpt::system::VerbosityLevel>::name2value(
-            argVerbosityMVSIM.getValue()));
+            argVerbosityMVSIM));
 
     server->start();
 }
@@ -253,13 +212,13 @@ void prepare_selfdriving(mvsim::World& world)
 
     sd->navigator.setMinLoggingLevel(
         mrpt::typemeta::TEnumType<mrpt::system::VerbosityLevel>::name2value(
-            argVerbosity.getValue()));
+            argVerbosity));
 
     // Load PTGs:
     {
-        mrpt::config::CConfigFile cfg(arg_ptgs_file.getValue());
+        mrpt::config::CConfigFile cfg(arg_ptgs_file);
         sd->navigator.config_.ptgs.initFromConfigFile(
-            cfg, arg_config_file_section.getValue());
+            cfg, arg_config_file_section);
     }
 
     // Obstacle source:
@@ -274,9 +233,9 @@ void prepare_selfdriving(mvsim::World& world)
         static_cast<unsigned int>(obsPts->size()));
 
     // Vehicle interface:
-    if (argVehicleInterface.isSet())
+    if (argVehicleInterface_set)
     {
-        const auto name = argVehicleInterface.getValue();
+        const auto name = argVehicleInterface;
         auto       obj  = mrpt::rtti::classFactory(name);
         ASSERTMSG_(
             obj, mrpt::format("Unregistered class name '%s'", name.c_str()));
@@ -307,9 +266,9 @@ void prepare_selfdriving(mvsim::World& world)
     }
 
     // target approach controller:
-    if (argTargetApproachController.isSet())
+    if (argTargetApproachController_set)
     {
-        const auto name = argTargetApproachController.getValue();
+        const auto name = argTargetApproachController;
         auto       obj  = mrpt::rtti::classFactory(name);
         ASSERTMSG_(
             obj, mrpt::format("Unregistered class name '%s'", name.c_str()));
@@ -327,43 +286,39 @@ void prepare_selfdriving(mvsim::World& world)
             sd->navigator.getMinLoggingLevel());
     }
 
-    if (arg_planner_yaml_file.isSet())
+    if (arg_planner_yaml_file_set)
     {
         sd->navigator.config_.plannerParams =
             mpp::TPS_Astar_Parameters::FromYAML(
-                mrpt::containers::yaml::FromFile(
-                    arg_planner_yaml_file.getValue()));
+                mrpt::containers::yaml::FromFile(arg_planner_yaml_file));
     }
 
-    if (arg_cost_global_yaml_file.isSet())
+    if (arg_cost_global_yaml_file_set)
     {
         sd->navigator.config_.globalCostParameters =
             mpp::CostEvaluatorCostMap::Parameters::FromYAML(
-                mrpt::containers::yaml::FromFile(
-                    arg_cost_global_yaml_file.getValue()));
+                mrpt::containers::yaml::FromFile(arg_cost_global_yaml_file));
     }
 
-    if (arg_cost_local_yaml_file.isSet())
+    if (arg_cost_local_yaml_file_set)
     {
         sd->navigator.config_.localCostParameters =
             mpp::CostEvaluatorCostMap::Parameters::FromYAML(
-                mrpt::containers::yaml::FromFile(
-                    arg_cost_local_yaml_file.getValue()));
+                mrpt::containers::yaml::FromFile(arg_cost_local_yaml_file));
     }
 
-    if (arg_cost_prefer_waypoints_yaml_file.isSet())
+    if (arg_cost_prefer_waypoints_yaml_file_set)
     {
         sd->navigator.config_.preferWaypointsParameters =
             mpp::CostEvaluatorPreferredWaypoint::Parameters::FromYAML(
                 mrpt::containers::yaml::FromFile(
-                    arg_cost_prefer_waypoints_yaml_file.getValue()));
+                    arg_cost_prefer_waypoints_yaml_file));
     }
 
-    if (arg_nav_engine_yaml_file.isSet())
+    if (arg_nav_engine_yaml_file_set)
     {
         sd->navigator.config_.loadFrom(
-            mrpt::containers::yaml::FromFile(
-                arg_nav_engine_yaml_file.getValue()));
+            mrpt::containers::yaml::FromFile(arg_nav_engine_yaml_file));
     }
 
     // all mandaroty fields filled in now:
@@ -374,11 +329,10 @@ void prepare_selfdriving(mvsim::World& world)
 
     // Load example/test waypoints?
     // --------------------------------------------------------
-    if (arg_waypoints_yaml_file.isSet())
+    if (arg_waypoints_yaml_file_set)
     {
         sd->waypts = mpp::WaypointSequence::FromYAML(
-            mrpt::containers::yaml::FromFile(
-                arg_waypoints_yaml_file.getValue()));
+            mrpt::containers::yaml::FromFile(arg_waypoints_yaml_file));
     }
 }
 
@@ -388,7 +342,7 @@ int launchSimulation()
 
     sd = std::make_shared<SelfDrivingStatus>();
 
-    const auto sXMLfilename = argMvsimFile.getValue();
+    const auto sXMLfilename = argMvsimFile;
 
     // Start network server:
     commonLaunchServer();
@@ -397,7 +351,7 @@ int launchSimulation()
 
     world->setMinLoggingLevel(
         mrpt::typemeta::TEnumType<mrpt::system::VerbosityLevel>::name2value(
-            argVerbosityMVSIM.getValue()));
+            argVerbosityMVSIM));
 
     // Load from XML:
     world->load_from_XML_file(sXMLfilename);
@@ -579,7 +533,7 @@ void prepare_selfdriving_window(
     // prepare custom gl objects for selfdriving lib:
     {
         auto lckgui               = mrpt::lockHelper(world->guiUserObjectsMtx_);
-        world->guiUserObjectsViz_ = mrpt::opengl::CSetOfObjects::Create();
+        world->guiUserObjectsViz_ = mrpt::viz::CSetOfObjects::Create();
         world->guiUserObjectsViz_->setName("gui_user_objects_viz");
 
         sd->navigator.config_.vizSceneToModify = world->guiUserObjectsViz_;
@@ -639,13 +593,12 @@ void prepare_selfdriving_window(
         auto pnNav        = wrappers.at(0);
         auto lbWaypsCount = pnNav->add<nanogui::Label>("");
 
-        lbWaypsCount->setCaption(
-            mrpt::format(
-                "Number of wps: %u",
-                static_cast<unsigned int>(sd->waypts.waypoints.size())));
+        lbWaypsCount->setCaption(mrpt::format(
+            "Number of wps: %u",
+            static_cast<unsigned int>(sd->waypts.waypoints.size())));
 
         // custom 3D objects
-        auto glWaypoints = mrpt::opengl::CSetOfObjects::Create();
+        auto glWaypoints = mrpt::viz::CSetOfObjects::Create();
         glWaypoints->setLocation(0, 0, 0.01);
         glWaypoints->setName("glWaypoints");
         mpp::WaypointsRenderingParams rp;
@@ -684,11 +637,10 @@ void prepare_selfdriving_window(
     const auto lambdaUpdateNavStatus = [lbNavStatus]()
     {
         const auto state = sd->navigator.current_status();
-        lbNavStatus->setCaption(
-            mrpt::format(
-                "Nav status: %s",
-                mrpt::typemeta::TEnumType<mpp::NavStatus>::value2name(state)
-                    .c_str()));
+        lbNavStatus->setCaption(mrpt::format(
+            "Nav status: %s",
+            mrpt::typemeta::TEnumType<mpp::NavStatus>::value2name(state)
+                .c_str()));
     };
 
     // -------------------------------
@@ -709,7 +661,7 @@ void prepare_selfdriving_window(
         edStateStartVel->setEditable(true);
 
         // custom 3D objects
-        auto glTargetSign = mrpt::opengl::CDisk::Create(1.0, 0.8);
+        auto glTargetSign = mrpt::viz::CDisk::Create(1.0, 0.8);
         glTargetSign->setColor_u8(0xff, 0x00, 0x00, 0xa0);
         glTargetSign->setName("glTargetSign");
         glTargetSign->setVisibility(false);
@@ -895,8 +847,7 @@ void mvsim_server_thread_update_GUI(GUI_ThreadParams& tp)
         if (firstTime && tp.world->gui_window())
         {
             tp.world->enqueue_task_to_run_in_gui_thread(
-                [&]()
-                {
+                [&]() {
                     prepare_selfdriving_window(
                         tp.world->gui_window(), tp.world);
                 });
@@ -964,7 +915,7 @@ void on_do_single_path_planning(
     {
         const auto bboxMargin = mrpt::math::TPoint3Df(1.0, 1.0, .0);
         const auto ptStart    = mrpt::math::TPoint3Df(
-            pi.stateStart.pose.x, pi.stateStart.pose.y, 0);
+               pi.stateStart.pose.x, pi.stateStart.pose.y, 0);
         const auto ptGoal = mrpt::math::TPoint3Df(
             pi.stateGoal.asSE2KinState().pose.x,
             pi.stateGoal.asSE2KinState().pose.y, 0);
@@ -1021,10 +972,10 @@ void on_do_single_path_planning(
     }
 
     // Set planner required params:
-    if (arg_planner_yaml_file.isSet())
+    if (arg_planner_yaml_file_set)
     {
-        const auto sFile = arg_planner_yaml_file.getValue();
-        const auto c     = mrpt::containers::yaml::FromFile(sFile);
+        const auto& sFile = arg_planner_yaml_file;
+        const auto  c     = mrpt::containers::yaml::FromFile(sFile);
         planner.params_.load_from_yaml(c);
         std::cout << "Loaded these planner params:\n";
         planner.params_.as_yaml().printAsYAML();
@@ -1034,8 +985,8 @@ void on_do_single_path_planning(
     planner.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
 
     // PTGs config file:
-    mrpt::config::CConfigFile cfg(arg_ptgs_file.getValue());
-    pi.ptgs.initFromConfigFile(cfg, arg_config_file_section.getValue());
+    mrpt::config::CConfigFile cfg(arg_ptgs_file);
+    pi.ptgs.initFromConfigFile(cfg, arg_config_file_section);
 
     const mpp::PlannerOutput plan = planner.plan(pi);
 
@@ -1055,13 +1006,70 @@ int main(int argc, char** argv)
 {
     try
     {
-        if (!cmd.parse(argc, argv)) return 1;
+        app.add_option(
+            "-v,--verbose", argVerbosity, "Verbosity level for path planner.");
+        app.add_option(
+            "--verbose-mvsim", argVerbosityMVSIM,
+            "Verbosity level for the mvsim subsystem.");
+        app.add_option(
+            "--config-section", arg_config_file_section,
+            "If loading from an INI file, the name of the section to load.");
+        app.add_option("-s,--simul-file", argMvsimFile, "MVSIM XML file.")
+            ->required();
+        app.add_option(
+            "--vehicle-interface-class", argVehicleInterface,
+            "Class name to use (Default: 'mpp::MVSIM_VehicleInterface').");
+        app.add_option(
+            "--approach-controller-class", argTargetApproachController,
+            "Class name to use as target approach controller (Default: none).");
+        app.add_option(
+               "-p,--ptg-config", arg_ptgs_file,
+               "Input .ini file with PTG definitions.")
+            ->required();
+        app.add_option(
+            "--planner-parameters", arg_planner_yaml_file,
+            "Input .yaml file with planner parameters.");
+        app.add_option(
+            "--prefer-waypoints-parameters",
+            arg_cost_prefer_waypoints_yaml_file,
+            "Input .yaml file with costmap parameters.");
+        app.add_option(
+            "--global-costmap-parameters", arg_cost_global_yaml_file,
+            "Input .yaml file with global obstacle points costmap parameters.");
+        app.add_option(
+            "--local-costmap-parameters", arg_cost_local_yaml_file,
+            "Input .yaml file with local obstacle points costmap parameters.");
+        app.add_option(
+            "--nav-engine-parameters", arg_nav_engine_yaml_file,
+            "Input .yaml file with parameters for NavEngine.");
+        app.add_option(
+            "--waypoints", arg_waypoints_yaml_file,
+            "Input .yaml file with waypoints.");
+        app.add_option(
+            "--plugins", arg_plugins,
+            "Optional plug-in libraries to load, for externally-defined PTGs.");
 
-        if (arg_plugins.isSet())
+        CLI11_PARSE(app, argc, argv);
+
+        argVehicleInterface_set = (app.count("--vehicle-interface-class") > 0);
+        argTargetApproachController_set =
+            (app.count("--approach-controller-class") > 0);
+        arg_planner_yaml_file_set = (app.count("--planner-parameters") > 0);
+        arg_cost_prefer_waypoints_yaml_file_set =
+            (app.count("--prefer-waypoints-parameters") > 0);
+        arg_cost_global_yaml_file_set =
+            (app.count("--global-costmap-parameters") > 0);
+        arg_cost_local_yaml_file_set =
+            (app.count("--local-costmap-parameters") > 0);
+        arg_nav_engine_yaml_file_set =
+            (app.count("--nav-engine-parameters") > 0);
+        arg_waypoints_yaml_file_set = (app.count("--waypoints") > 0);
+        arg_plugins_set             = (app.count("--plugins") > 0);
+
+        if (arg_plugins_set)
         {
             std::string loadErrors;
-            if (!mrpt::system::loadPluginModules(
-                    arg_plugins.getValue(), loadErrors))
+            if (!mrpt::system::loadPluginModules(arg_plugins, loadErrors))
             {
                 std::cerr << "Could not load plugins, error: " << loadErrors;
                 return 1;

--- a/mrpt_path_planning_core/CMakeLists.txt
+++ b/mrpt_path_planning_core/CMakeLists.txt
@@ -38,11 +38,10 @@ endif()
 # NOTE: mrpt-gui and mvsim are intentionally NOT requested here, so this
 # package (and everything that depends on it) has no GUI/display dependency.
 # See mrpt_path_planning_apps for the CLI/GUI applications.
-find_package(mrpt-tclap REQUIRED)
-find_package(mrpt-containers REQUIRED)
-find_package(mrpt-graphs REQUIRED)
-find_package(mrpt-nav REQUIRED)
-find_package(mrpt-maps REQUIRED)
+find_package(mrpt_containers REQUIRED)
+find_package(mrpt_graphs REQUIRED)
+find_package(mrpt_nav REQUIRED)
+find_package(mrpt_maps REQUIRED)
 
 # Explicit source/header lists (kept in sync by hand rather than globbed, so
 # that adding/removing a file is a visible, reviewable change and reliably
@@ -137,10 +136,10 @@ selfdriving_add_library(
 	SOURCES
 		${LIB_SRCS} ${LIB_PUBLIC_HDRS}
 	PUBLIC_LINK_LIBRARIES
-		mrpt::nav mrpt::graphs mrpt::containers mrpt::maps
+		mrpt::mrpt_nav mrpt::mrpt_graphs mrpt::mrpt_containers mrpt::mrpt_maps
 #	[PRIVATE_LINK_LIBRARIES lib3 lib4]
 	CMAKE_DEPENDENCIES
-		mrpt-containers mrpt-graphs mrpt-nav mrpt-maps
+		mrpt_containers mrpt_graphs mrpt_nav mrpt_maps
 )
 
 option(MRPT_PATH_PLANNING_BUILD_TESTS "Build mrpt_path_planning unit tests" ON)

--- a/mrpt_path_planning_core/include/mpp/algos/CostEvaluator.h
+++ b/mrpt_path_planning_core/include/mpp/algos/CostEvaluator.h
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <mpp/data/MoveEdgeSE2_TPS.h>
-#include <mrpt/opengl/CSetOfObjects.h>
 #include <mrpt/rtti/CObject.h>
 #include <mrpt/version.h>
+#include <mrpt/viz/CSetOfObjects.h>
 
 // fwd decl:
 namespace mrpt::maps
@@ -35,7 +35,7 @@ class CostEvaluator : public mrpt::rtti::CObject
     virtual double operator()(const MoveEdgeSE2_TPS& edge) const = 0;
 
     // Default: empty viz
-    virtual mrpt::opengl::CSetOfObjects::Ptr get_visualization() const;
+    virtual mrpt::viz::CSetOfObjects::Ptr get_visualization() const;
 
     // Default: empty grid. Used mostly for ROS visualization interface
     virtual std::shared_ptr<mrpt::maps::COccupancyGridMap2D>

--- a/mrpt_path_planning_core/include/mpp/algos/CostEvaluatorCostMap.h
+++ b/mrpt_path_planning_core/include/mpp/algos/CostEvaluatorCostMap.h
@@ -79,7 +79,7 @@ class CostEvaluatorCostMap : public CostEvaluator
     /** Evaluate cost of move-tree edge */
     double operator()(const MoveEdgeSE2_TPS& edge) const override;
 
-    mrpt::opengl::CSetOfObjects::Ptr get_visualization() const override;
+    mrpt::viz::CSetOfObjects::Ptr get_visualization() const override;
 
     // Used for ROS visualization interface
     std::shared_ptr<mrpt::maps::COccupancyGridMap2D> get_visualization_as_grid()

--- a/mrpt_path_planning_core/include/mpp/algos/CostEvaluatorPreferredWaypoint.h
+++ b/mrpt_path_planning_core/include/mpp/algos/CostEvaluatorPreferredWaypoint.h
@@ -53,7 +53,7 @@ class CostEvaluatorPreferredWaypoint : public CostEvaluator
     /** Evaluate cost of move-tree edge */
     double operator()(const MoveEdgeSE2_TPS& edge) const override;
 
-    mrpt::opengl::CSetOfObjects::Ptr get_visualization() const override;
+    mrpt::viz::CSetOfObjects::Ptr get_visualization() const override;
 
     const Parameters& params() const { return params_; }
 

--- a/mrpt_path_planning_core/include/mpp/algos/NavEngine.h
+++ b/mrpt_path_planning_core/include/mpp/algos/NavEngine.h
@@ -172,9 +172,9 @@ class NavEngine : public mrpt::system::COutputLogger
         /**  \name Visualization callbacks and methods
          *   @{ */
 
-        std::function<void(void)>                    on_viz_pre_modify;
-        std::shared_ptr<mrpt::opengl::CSetOfObjects> vizSceneToModify;
-        std::function<void(void)>                    on_viz_post_modify;
+        std::function<void(void)>                 on_viz_pre_modify;
+        std::shared_ptr<mrpt::viz::CSetOfObjects> vizSceneToModify;
+        std::function<void(void)>                 on_viz_post_modify;
 
         /** @} */
     };
@@ -477,8 +477,8 @@ class NavEngine : public mrpt::system::COutputLogger
          *  @{ */
         /** Copy of sent-out cmd, for the log record */
         mrpt::kinematics::CVehicleVelCmd::Ptr sentOutCmdInThisIteration;
-        mrpt::opengl::CSetOfObjects::Ptr      planVizForNavLog;
-        mrpt::opengl::CSetOfObjects::Ptr      stateVizForNavLog;
+        mrpt::viz::CSetOfObjects::Ptr         planVizForNavLog;
+        mrpt::viz::CSetOfObjects::Ptr         stateVizForNavLog;
         std::vector<std::string>              navlogDebugMessages;
 
         std::optional<double> lastNavigationStepEndTime;

--- a/mrpt_path_planning_core/include/mpp/algos/render_tree.h
+++ b/mrpt_path_planning_core/include/mpp/algos/render_tree.h
@@ -9,7 +9,7 @@
 #include <mpp/data/MotionPrimitivesTree.h>
 #include <mpp/data/PlannerInput.h>
 #include <mpp/data/RenderOptions.h>
-#include <mrpt/opengl/opengl_frwds.h>
+#include <mrpt/viz/viz_frwds.h>
 
 #include <memory>
 
@@ -18,6 +18,6 @@ namespace mpp
 /** Gets a CSetOfObjects::Ptr visual representation of a motion tree */
 auto render_tree(
     const MotionPrimitivesTreeSE2& tree, const PlannerInput& pi,
-    const RenderOptions& ro) -> std::shared_ptr<mrpt::opengl::CSetOfObjects>;
+    const RenderOptions& ro) -> std::shared_ptr<mrpt::viz::CSetOfObjects>;
 
 }  // namespace mpp

--- a/mrpt_path_planning_core/include/mpp/algos/render_vehicle.h
+++ b/mrpt_path_planning_core/include/mpp/algos/render_vehicle.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <mpp/data/TrajectoriesAndRobotShape.h>
-#include <mrpt/opengl/opengl_frwds.h>
+#include <mrpt/viz/viz_frwds.h>
 
 #include <memory>
 
@@ -29,7 +29,7 @@ struct RenderVehicleExtraResults
 
 /** Generates a polygon for the vehicle shape */
 auto render_vehicle(
-    const RobotShape& rs, mrpt::opengl::CSetOfLines& outPolygon,
+    const RobotShape& rs, mrpt::viz::CSetOfLines& outPolygon,
     const RenderVehicleParams& rvp = {}) -> RenderVehicleExtraResults;
 
 }  // namespace mpp

--- a/mrpt_path_planning_core/include/mpp/data/MotionPrimitivesTree.h
+++ b/mrpt_path_planning_core/include/mpp/data/MotionPrimitivesTree.h
@@ -337,8 +337,11 @@ struct PoseDistanceMetric_TPS<SE2_KinState>
 
         ptg_.updateNavDynamicState(dynState);
 
-        bool tp_point_is_exact =
-            ptg_.inverseMap_WS2TP(relPose.x, relPose.y, k, normDist);
+        const auto invMap = ptg_.inverseMap_WS2TP(relPose.x, relPose.y);
+        bool       tp_point_is_exact = invMap.has_value();
+
+        k        = tp_point_is_exact ? invMap->first : 0;
+        normDist = tp_point_is_exact ? invMap->second : 0.0;
 
         distance_t d = normDist * ptg_.getRefDistance();
 
@@ -349,9 +352,8 @@ struct PoseDistanceMetric_TPS<SE2_KinState>
             const auto   reconsRelPose = ptg_.getPathPose(k, ptg_step);
             const double headingError =
                 ignoreDstHeading ? .0
-                                 : std::abs(
-                                       mrpt::math::angDistance(
-                                           reconsRelPose.phi, relPose.phi));
+                                 : std::abs(mrpt::math::angDistance(
+                                       reconsRelPose.phi, relPose.phi));
 
             if (headingError > headingTolerance_) tp_point_is_exact = false;
         }

--- a/mrpt_path_planning_core/include/mpp/data/Waypoints.h
+++ b/mrpt_path_planning_core/include/mpp/data/Waypoints.h
@@ -12,8 +12,8 @@
 #include <mrpt/img/TColor.h>
 #include <mrpt/math/TPoint2D.h>
 #include <mrpt/math/TPose2D.h>
-#include <mrpt/opengl/opengl_frwds.h>
 #include <mrpt/system/datetime.h>
+#include <mrpt/viz/viz_frwds.h>
 
 #include <optional>
 #include <string>
@@ -157,7 +157,7 @@ struct WaypointSequence
     /** Renders the sequence of waypoints (previous contents of `obj` are
      * cleared) */
     void getAsOpenglVisualization(
-        mrpt::opengl::CSetOfObjects&    obj,
+        mrpt::viz::CSetOfObjects&       obj,
         const WaypointsRenderingParams& params = {}) const;
 
     /** Save waypoints as YAML */
@@ -232,7 +232,7 @@ struct WaypointStatusSequence
     /** Renders the sequence of waypoints (previous contents of `obj` are
      * cleared) */
     void getAsOpenglVisualization(
-        mrpt::opengl::CSetOfObjects&    obj,
+        mrpt::viz::CSetOfObjects&       obj,
         const WaypointsRenderingParams& params = {}) const;
 };
 }  // namespace mpp

--- a/mrpt_path_planning_core/include/mpp/ptgs/DiffDriveCollisionGridBased.h
+++ b/mrpt_path_planning_core/include/mpp/ptgs/DiffDriveCollisionGridBased.h
@@ -13,6 +13,9 @@
 #include <mrpt/nav/tpspace/CParameterizedTrajectoryGenerator.h>
 #include <mrpt/typemeta/TEnumType.h>
 
+#include <optional>
+#include <utility>
+
 namespace mpp::ptg
 {
 struct TCPoint
@@ -66,9 +69,8 @@ class DiffDriveCollisionGridBased : public mrpt::nav::CPTG_RobotShape_Polygonal
      * exist.
      * See full docs in base class
      * CParameterizedTrajectoryGenerator::inverseMap_WS2TP() */
-    bool inverseMap_WS2TP(
-        double x, double y, int& out_k, double& out_d,
-        double tolerance_dist = 0.10) const override;
+    [[nodiscard]] std::optional<std::pair<int, double>> inverseMap_WS2TP(
+        double x, double y, double tolerance_dist = 0.10) const override;
 
     /** In this class, `out_action_cmd` contains: [0]: linear velocity (m/s),
      * [1]: angular velocity (rad/s).

--- a/mrpt_path_planning_core/include/mpp/ptgs/DiffDrive_C.h
+++ b/mrpt_path_planning_core/include/mpp/ptgs/DiffDrive_C.h
@@ -56,9 +56,8 @@ class DiffDrive_C : public DiffDriveCollisionGridBased, public SpeedTrimmablePTG
         const std::string&             sSection) const override;
 
     std::string getDescription() const override;
-    bool        inverseMap_WS2TP(
-               double x, double y, int& out_k, double& out_d,
-               double tolerance_dist = 0.10) const override;
+    [[nodiscard]] std::optional<std::pair<int, double>> inverseMap_WS2TP(
+        double x, double y, double tolerance_dist = 0.10) const override;
     bool PTG_IsIntoDomain(double x, double y) const override;
     void ptgDiffDriveSteeringFunction(
         float alpha, float t, float x, float y, float phi, float& v,

--- a/mrpt_path_planning_core/include/mpp/ptgs/HolonomicBlend.h
+++ b/mrpt_path_planning_core/include/mpp/ptgs/HolonomicBlend.h
@@ -19,6 +19,8 @@
 #include <mrpt/nav/tpspace/CParameterizedTrajectoryGenerator.h>
 
 #include <mutex>
+#include <optional>
+#include <utility>
 
 namespace mpp::ptg
 {
@@ -53,9 +55,8 @@ class HolonomicBlend : public SpeedTrimmablePTG,
     double maxTimeInVelCmdNOP(int path_k) const override;
 
     std::string getDescription() const override;
-    bool        inverseMap_WS2TP(
-               double x, double y, int& out_k, double& out_d,
-               double tolerance_dist = 0.10) const override;
+    [[nodiscard]] std::optional<std::pair<int, double>> inverseMap_WS2TP(
+        double x, double y, double tolerance_dist = 0.10) const override;
     bool PTG_IsIntoDomain(double x, double y) const override;
     void onNewNavDynamicState() override;
 

--- a/mrpt_path_planning_core/package.xml
+++ b/mrpt_path_planning_core/package.xml
@@ -16,11 +16,10 @@
   <license>BSD</license>
 
   <!-- Deps required by user code (they are in public headers or built as ROS (vs system) packages -->
-  <depend>mrpt_libmaps</depend>
-  <depend>mrpt_libnav</depend>
-  <depend>mrpt_libgraphs</depend>
-  <depend>mrpt_libcontainers</depend>
-  <depend>mrpt_libtclap</depend>
+  <depend>mrpt_maps</depend>
+  <depend>mrpt_nav</depend>
+  <depend>mrpt_graphs</depend>
+  <depend>mrpt_containers</depend>
 
   <test_depend>libgtest-dev</test_depend>
 

--- a/mrpt_path_planning_core/src/algos/CostEvaluator.cpp
+++ b/mrpt_path_planning_core/src/algos/CostEvaluator.cpp
@@ -13,10 +13,10 @@ IMPLEMENTS_VIRTUAL_MRPT_OBJECT(CostEvaluator, mrpt::rtti::CObject, mpp)
 
 CostEvaluator::~CostEvaluator() = default;
 
-mrpt::opengl::CSetOfObjects::Ptr CostEvaluator::get_visualization() const
+mrpt::viz::CSetOfObjects::Ptr CostEvaluator::get_visualization() const
 {
     // Default: empty viz
-    auto glObj = mrpt::opengl::CSetOfObjects::Create();
+    auto glObj = mrpt::viz::CSetOfObjects::Create();
     glObj->setName("CostEvaluator.default");
     return glObj;
 }

--- a/mrpt_path_planning_core/src/algos/CostEvaluatorCostMap.cpp
+++ b/mrpt_path_planning_core/src/algos/CostEvaluatorCostMap.cpp
@@ -8,7 +8,7 @@
 #include <mpp/data/robot_shape_sampling.h>
 #include <mrpt/img/color_maps.h>
 #include <mrpt/maps/COccupancyGridMap2D.h>
-#include <mrpt/opengl/CTexturedPlane.h>
+#include <mrpt/viz/CTexturedPlane.h>
 
 #include <algorithm>
 #include <cmath>
@@ -204,14 +204,14 @@ double CostEvaluatorCostMap::eval_single_pose(
     return maxCost;
 }
 
-mrpt::opengl::CSetOfObjects::Ptr CostEvaluatorCostMap::get_visualization() const
+mrpt::viz::CSetOfObjects::Ptr CostEvaluatorCostMap::get_visualization() const
 {
     const uint8_t COST_TRANSPARENCY_ALPHA = 0x80;
     const double  MIN_COST_TO_TRANSPARENT = 0.02;
 
-    auto glObjs = mrpt::opengl::CSetOfObjects::Create();
+    auto glObjs = mrpt::viz::CSetOfObjects::Create();
     glObjs->setName("CostEvaluatorCostMap");
-    auto glPlane = mrpt::opengl::CTexturedPlane::Create();
+    auto glPlane = mrpt::viz::CTexturedPlane::Create();
     glObjs->insert(glPlane);
 
     glPlane->setPlaneCorners(
@@ -224,9 +224,13 @@ mrpt::opengl::CSetOfObjects::Ptr CostEvaluatorCostMap::get_visualization() const
     mrpt::img::CImage gridALPHA(nCols, nRows, mrpt::img::CH_GRAY);
 
     gridRGB.filledRectangle(
-        0, 0, nCols - 1, nRows - 1, mrpt::img::TColor::black());
+        mrpt::img::TPixelCoord(0, 0),
+        mrpt::img::TPixelCoord(nCols - 1, nRows - 1),
+        mrpt::img::TColor::black());
     gridALPHA.filledRectangle(
-        0, 0, nCols - 1, nRows - 1, mrpt::img::TColor::black());
+        mrpt::img::TPixelCoord(0, 0),
+        mrpt::img::TPixelCoord(nCols - 1, nRows - 1),
+        mrpt::img::TColor::black());
 
     for (size_t icy = 0; icy < nRows; icy++)
     {
@@ -235,18 +239,21 @@ mrpt::opengl::CSetOfObjects::Ptr CostEvaluatorCostMap::get_visualization() const
             const double* c = costmap_.cellByIndex(icx, icy);
             if (!c) continue;
             const double val = *c;
+            const auto   col = static_cast<int32_t>(icx);
+            const auto   row = static_cast<int32_t>(icy);
             if (val < MIN_COST_TO_TRANSPARENT)
             {
-                *gridALPHA(icx, icy) = 0x00;  // 100% transparent
+                gridALPHA.at<uint8_t>(col, row) = 0x00;  // 100% transparent
             }
             else
             {
-                *gridALPHA(icx, icy) = COST_TRANSPARENCY_ALPHA;
+                gridALPHA.at<uint8_t>(col, row) = COST_TRANSPARENCY_ALPHA;
 
-                const mrpt::img::TColor cellColor = mrpt::img::colormap(
-                    mrpt::img::cmJET, val / params_.maxCost);
+                const mrpt::img::TColor cellColor =
+                    mrpt::img::colormap(mrpt::img::cmJET, val / params_.maxCost)
+                        .asTColor();
 
-                uint8_t* bgr = gridRGB(icx, icy);
+                uint8_t* bgr = gridRGB.ptr<uint8_t>(col, row);
                 bgr[0]       = cellColor.B;
                 bgr[1]       = cellColor.G;
                 bgr[2]       = cellColor.R;

--- a/mrpt_path_planning_core/src/algos/CostEvaluatorPreferredWaypoint.cpp
+++ b/mrpt_path_planning_core/src/algos/CostEvaluatorPreferredWaypoint.cpp
@@ -5,7 +5,7 @@
  * ------------------------------------------------------------------------- */
 
 #include <mpp/algos/CostEvaluatorPreferredWaypoint.h>
-#include <mrpt/opengl/CDisk.h>
+#include <mrpt/viz/CDisk.h>
 
 using namespace mpp;
 
@@ -120,10 +120,10 @@ double CostEvaluatorPreferredWaypoint::eval_single_pose(
     return std::max(.0, cost);
 }
 
-mrpt::opengl::CSetOfObjects::Ptr
+mrpt::viz::CSetOfObjects::Ptr
     CostEvaluatorPreferredWaypoint::get_visualization() const
 {
-    auto glObjs = mrpt::opengl::CSetOfObjects::Create();
+    auto glObjs = mrpt::viz::CSetOfObjects::Create();
     glObjs->setName("CostEvaluatorPreferredWaypoint");
 
     for (size_t i = 0; i < waypoints_.size(); i++)
@@ -131,7 +131,7 @@ mrpt::opengl::CSetOfObjects::Ptr
         float x, y;
         waypoints_.getPoint(i, x, y);
 
-        auto glDisk = mrpt::opengl::CDisk::Create();
+        auto glDisk = mrpt::viz::CDisk::Create();
         glDisk->setColor_u8(0x20, 0x20, 0xff, 0x20);
         glDisk->setDiskRadius(
             params_.waypointInfluenceRadius,

--- a/mrpt_path_planning_core/src/algos/NavEngine.cpp
+++ b/mrpt_path_planning_core/src/algos/NavEngine.cpp
@@ -15,11 +15,11 @@
 #include <mrpt/core/lock_helper.h>
 #include <mrpt/math/TSegment2D.h>
 #include <mrpt/nav/reactive/CLogFileRecord.h>
-#include <mrpt/opengl/COpenGLScene.h>
-#include <mrpt/opengl/stock_objects.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/version.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/stock_objects.h>
 
 using namespace mpp;
 
@@ -355,8 +355,8 @@ void NavEngine::update_robot_kinematic_state()
             navigationStatus_          = NavStatus::NAV_ERROR;
             navErrorReason_.error_code = NavError::EMERGENCY_STOP;
             navErrorReason_.error_msg  = std::string(
-                "ERROR: get_localization() failed, stopping robot "
-                 "and finishing navigation");
+                 "ERROR: get_localization() failed, stopping robot "
+                  "and finishing navigation");
             try
             {
                 config_.vehicleMotionInterface->stop(STOP_TYPE::EMERGENCY);
@@ -743,8 +743,8 @@ NavEngine::PathPlannerOutput NavEngine::path_planner_function(
         {
             planner.costEvaluators_.push_back(
                 mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
-                    *obs, config_.globalCostParameters,
-                    ppi.pi.stateStart.pose, config_.ptgs.robotShape));
+                    *obs, config_.globalCostParameters, ppi.pi.stateStart.pose,
+                    config_.ptgs.robotShape));
         }
     }
 
@@ -1176,7 +1176,7 @@ void NavEngine::send_next_motion_cmd_or_nop()
         {
             uint32_t stepEnd = 0, stepAfter = 0;
             bool     ok1 = ptg->getPathStepForDist(
-                edge.ptgPathIndex, edge.ptgDist, stepEnd);
+                    edge.ptgPathIndex, edge.ptgDist, stepEnd);
             bool ok2 = ptg->getPathStepForDist(
                 edge.ptgPathIndex,
                 edge.ptgDist + config_.enqueuedActionsToleranceXY, stepAfter);
@@ -1314,7 +1314,7 @@ void NavEngine::send_planner_output_to_viz(const PathPlannerOutput& ppo)
     ro.ground_xy_grid_frequency  = 0;  // disabled
     ro.phi2z_scale               = 0;
 
-    mrpt::opengl::CSetOfObjects::Ptr planViz =
+    mrpt::viz::CSetOfObjects::Ptr planViz =
         render_tree(ppo.po.motionTree, ppo.po.originalInput, ro);
     planViz->setName("astar_plan_result");
 
@@ -1324,7 +1324,7 @@ void NavEngine::send_planner_output_to_viz(const PathPlannerOutput& ppo)
     // ----------------------------------
     if (!ppo.costEvaluators.empty())
     {
-        auto glCostMaps = mrpt::opengl::CSetOfObjects::Create();
+        auto glCostMaps = mrpt::viz::CSetOfObjects::Create();
         glCostMaps->setName("glCostMaps");
 
         float zOffset = 0.01f;  // to help visualize several costmaps at once
@@ -1354,14 +1354,11 @@ void NavEngine::send_planner_output_to_viz(const PathPlannerOutput& ppo)
             glObj)
         {
             auto glContainer =
-                std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(glObj);
+                std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(glObj);
             ASSERT_(glContainer);
             *glContainer = *planViz;
         }
-        else
-        {
-            config_.vizSceneToModify->insert(planViz);
-        }
+        else { config_.vizSceneToModify->insert(planViz); }
 
         // unlock:
         if (config_.on_viz_post_modify) config_.on_viz_post_modify();
@@ -1372,7 +1369,7 @@ void NavEngine::send_planner_output_to_viz(const PathPlannerOutput& ppo)
     {
         // Create object wrapper to fix coordinate origin, since the navlog
         // custom visuals are relative to the robot position, not global:
-        auto glGlobalWrtRobot = mrpt::opengl::CSetOfObjects::Create();
+        auto glGlobalWrtRobot = mrpt::viz::CSetOfObjects::Create();
         glGlobalWrtRobot->insert(planViz);
         glGlobalWrtRobot->setPose(-lastVehicleLocalization_.pose);
         innerState_.planVizForNavLog = glGlobalWrtRobot;
@@ -1394,7 +1391,7 @@ void NavEngine::send_path_to_viz_and_navlog(
     ro.ground_xy_grid_frequency  = 0;  // disabled
     ro.phi2z_scale               = 0;
 
-    mrpt::opengl::CSetOfObjects::Ptr planViz =
+    mrpt::viz::CSetOfObjects::Ptr planViz =
         render_tree(tree, originalPlanInput, ro);
     planViz->setName("astar_plan_result");
 
@@ -1404,7 +1401,7 @@ void NavEngine::send_path_to_viz_and_navlog(
     // ----------------------------------
     if (!costEvaluators.empty())
     {
-        auto glCostMaps = mrpt::opengl::CSetOfObjects::Create();
+        auto glCostMaps = mrpt::viz::CSetOfObjects::Create();
         glCostMaps->setName("glCostMaps");
 
         float zOffset = 0.01f;  // to help visualize several costmaps at once
@@ -1434,14 +1431,11 @@ void NavEngine::send_path_to_viz_and_navlog(
             glObj)
         {
             auto glContainer =
-                std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(glObj);
+                std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(glObj);
             ASSERT_(glContainer);
             *glContainer = *planViz;
         }
-        else
-        {
-            config_.vizSceneToModify->insert(planViz);
-        }
+        else { config_.vizSceneToModify->insert(planViz); }
 
         // unlock:
         if (config_.on_viz_post_modify) config_.on_viz_post_modify();
@@ -1452,7 +1446,7 @@ void NavEngine::send_path_to_viz_and_navlog(
     {
         // Create object wrapper to fix coordinate origin, since the navlog
         // custom visuals are relative to the robot position, not global:
-        auto glGlobalWrtRobot = mrpt::opengl::CSetOfObjects::Create();
+        auto glGlobalWrtRobot = mrpt::viz::CSetOfObjects::Create();
         glGlobalWrtRobot->insert(planViz);
         glGlobalWrtRobot->setPose(-lastVehicleLocalization_.pose);
         innerState_.planVizForNavLog = glGlobalWrtRobot;
@@ -1465,14 +1459,14 @@ void NavEngine::send_current_state_to_viz_and_navlog()
 
     const auto& _ = innerState_;
 
-    auto glStateDetails = mrpt::opengl::CSetOfObjects::Create();
+    auto glStateDetails = mrpt::viz::CSetOfObjects::Create();
     glStateDetails->setName("glStateDetails");
     glStateDetails->setLocation(0, 0, 0.02);  // to easy the vis wrt the ground
 
     // last poses track:
     if (const auto& poses = _.latestPoses; !poses.empty())
     {
-        auto glRobotPath = mrpt::opengl::CSetOfLines::Create();
+        auto glRobotPath = mrpt::viz::CSetOfLines::Create();
         glRobotPath->setColor_u8(0x80, 0x80, 0x80, 0x80);
         const auto p0 = poses.begin()->second;
         glRobotPath->appendLine(p0.x, p0.y, 0, p0.x, p0.y, 0);
@@ -1480,8 +1474,7 @@ void NavEngine::send_current_state_to_viz_and_navlog()
         {
             glRobotPath->appendLineStrip(p.second.x, p.second.y, 0);
 
-            auto glCorner =
-                mrpt::opengl::stock_objects::CornerXYSimple(0.1, 1.0);
+            auto glCorner = mrpt::viz::stock_objects::CornerXYSimple(0.1, 1.0);
             glCorner->setPose(p.second);
             glStateDetails->insert(glCorner);
         }
@@ -1501,7 +1494,7 @@ void NavEngine::send_current_state_to_viz_and_navlog()
         const mrpt::math::TPose2D p1 = {
             p.x + tol.x, p.y + tol.y, p.phi + tol.phi};
 
-        auto glCondPoly = mrpt::opengl::CSetOfLines::Create();
+        auto glCondPoly = mrpt::viz::CSetOfLines::Create();
         glCondPoly->setColor_u8(0xf0, 0xf0, 0xf0, 0xa0);
 
         glCondPoly->appendLine(p0.x, p0.y, 0, p1.x, p0.y, 0);
@@ -1512,14 +1505,12 @@ void NavEngine::send_current_state_to_viz_and_navlog()
         glStateDetails->insert(glCondPoly);
 
         {
-            auto glCorner =
-                mrpt::opengl::stock_objects::CornerXYSimple(0.15, 1.0);
+            auto glCorner = mrpt::viz::stock_objects::CornerXYSimple(0.15, 1.0);
             glCorner->setPose(p0);
             glStateDetails->insert(glCorner);
         }
         {
-            auto glCorner =
-                mrpt::opengl::stock_objects::CornerXYSimple(0.15, 1.0);
+            auto glCorner = mrpt::viz::stock_objects::CornerXYSimple(0.15, 1.0);
             glCorner->setPose(p1);
             glStateDetails->insert(glCorner);
         }
@@ -1529,7 +1520,7 @@ void NavEngine::send_current_state_to_viz_and_navlog()
         triggOdom.has_value() && !_.activePlanPath.empty() &&
         _.activePlanInitOdometry.has_value())
     {
-        auto glCorner = mrpt::opengl::stock_objects::CornerXYZ(0.15);
+        auto glCorner = mrpt::viz::stock_objects::CornerXYZ(0.15);
         glCorner->setPose(
             _.activePlanPath.at(0).pose +
             (triggOdom.value().odometry - _.activePlanInitOdometry.value()));
@@ -1539,7 +1530,7 @@ void NavEngine::send_current_state_to_viz_and_navlog()
     if (const auto& predPose = _.collisionCheckingPosePrediction;
         predPose.has_value())
     {
-        auto glVehShape = mrpt::opengl::CSetOfLines::Create();
+        auto glVehShape = mrpt::viz::CSetOfLines::Create();
 
         glVehShape->setLineWidth(1);
         glVehShape->setColor_u8(0x40, 0x40, 0x40, 0x80);
@@ -1563,14 +1554,11 @@ void NavEngine::send_current_state_to_viz_and_navlog()
             glObj)
         {
             auto glContainer =
-                std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(glObj);
+                std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(glObj);
             ASSERT_(glContainer);
             *glContainer = *glStateDetails;
         }
-        else
-        {
-            config_.vizSceneToModify->insert(glStateDetails);
-        }
+        else { config_.vizSceneToModify->insert(glStateDetails); }
 
         // unlock:
         if (config_.on_viz_post_modify) config_.on_viz_post_modify();
@@ -1581,7 +1569,7 @@ void NavEngine::send_current_state_to_viz_and_navlog()
     {
         // Create object wrapper to fix coordinate origin, since the navlog
         // custom visuals are relative to the robot position, not global:
-        auto glGlobalWrtRobot = mrpt::opengl::CSetOfObjects::Create();
+        auto glGlobalWrtRobot = mrpt::viz::CSetOfObjects::Create();
         glGlobalWrtRobot->insert(glStateDetails);
         glGlobalWrtRobot->setPose(-lastVehicleLocalization_.pose);
         innerState_.stateVizForNavLog = glGlobalWrtRobot;

--- a/mrpt_path_planning_core/src/algos/TPS_Astar.cpp
+++ b/mrpt_path_planning_core/src/algos/TPS_Astar.cpp
@@ -13,8 +13,8 @@
 #include <mpp/data/MotionPrimitivesTree.h>
 #include <mpp/ptgs/SpeedTrimmablePTG.h>
 #include <mrpt/math/wrap2pi.h>
-#include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/version.h>
+#include <mrpt/viz/Scene.h>
 
 #include <cmath>
 #include <iostream>
@@ -173,7 +173,7 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
         tree.root = n.id.value();
         tree.insert_root_node(tree.root, n.state);
 
-        n.gScore           = 0;
+        n.gScore = 0;
         n.fScore = params_.heuristic_epsilon * heuristic(n.state, in.stateGoal);
         n.pendingInOpenSet = true;
 
@@ -207,19 +207,19 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
     double tLastCallback = planInitTime;
 
     // Analytic goal expansion (deferred, optimality-preserving): when a
-    // collision-free edge lands in the goal cell we remember it as a *candidate*
-    // solution instead of terminating immediately. Stopping on the first such
-    // edge is greedy and can produce grossly suboptimal paths: with an SE(2)
-    // goal, a node that arrived at the goal xy but a couple of yaw cells off can
-    // only re-enter the exact goal cell through a near-full-circle PTG arc (with
-    // a tight turning radius), so that first edge is a ~360 deg loop (see
-    // fig:cases in the paper). We instead keep the cheapest goal-landing
-    // candidate and only commit once its actual cost is provably (eps-)optimal,
-    // i.e. <= the minimum fScore still pending in the open set (committed at the
-    // top of the loop). This preserves the early-termination speed-up without
-    // accepting the loop, and is a no-op for R(2) point goals (verified
-    // identical on the 300-world BARN sweep).
-    Node*  bestGoalCandidate = nullptr;
+    // collision-free edge lands in the goal cell we remember it as a
+    // *candidate* solution instead of terminating immediately. Stopping on the
+    // first such edge is greedy and can produce grossly suboptimal paths: with
+    // an SE(2) goal, a node that arrived at the goal xy but a couple of yaw
+    // cells off can only re-enter the exact goal cell through a
+    // near-full-circle PTG arc (with a tight turning radius), so that first
+    // edge is a ~360 deg loop (see fig:cases in the paper). We instead keep the
+    // cheapest goal-landing candidate and only commit once its actual cost is
+    // provably (eps-)optimal, i.e. <= the minimum fScore still pending in the
+    // open set (committed at the top of the loop). This preserves the
+    // early-termination speed-up without accepting the loop, and is a no-op for
+    // R(2) point goals (verified identical on the 300-world BARN sweep).
+    Node*  bestGoalCandidate  = nullptr;
     cost_t bestGoalCandidateG = std::numeric_limits<cost_t>::max();
 
     // Defer building per-edge interpolated paths during the search: it is a
@@ -494,8 +494,8 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
             // Analytic expansion: this accepted edge connects (collision-free)
             // into the goal cell. Remember it as a candidate solution (keeping
             // the cheapest); we only commit to it once it is provably optimal,
-            // at the top of the while loop. See the note where bestGoalCandidate
-            // is declared.
+            // at the top of the while loop. See the note where
+            // bestGoalCandidate is declared.
             if (params_.use_analytic_expansion &&
                 edge.neighborNodeCoords.sameLocation(goalCellIndices) &&
                 neighborNode.gScore < bestGoalCandidateG)
@@ -519,7 +519,7 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
             RenderOptions ro;
             ro.highlight_path_to_node_id = current.id.value();
             ro.showEdgeCosts = params_.debugVisualizationShowEdgeCosts;
-            mrpt::opengl::COpenGLScene scene;
+            mrpt::viz::Scene scene;
             scene.insert(render_tree(tree, in, ro));
             scene.saveToFile(mrpt::format("debug_astar_%05u.3Dscene", nIter));
         }
@@ -768,13 +768,14 @@ TPS_Astar::list_paths_to_neighbors_t
         // make sure of including the trajectory towards the target, if we
         // are close enough, plus its immediate neighboring paths:
         {
-            int                   relTrg_k       = 0;
-            normalized_distance_t relTrg_d       = 0;
-            const double          queryTolerance = params_.grid_resolution_xy;
-            if (ptg->inverseMap_WS2TP(
-                    relGoal.x, relGoal.y, relTrg_k, relTrg_d, queryTolerance))
+            const double queryTolerance = params_.grid_resolution_xy;
+            const auto   trgInvMap =
+                ptg->inverseMap_WS2TP(relGoal.x, relGoal.y, queryTolerance);
+            if (trgInvMap.has_value())
             {
-                ptg_step_t relTrg_step = 0;
+                const int                   relTrg_k    = trgInvMap->first;
+                const normalized_distance_t relTrg_d    = trgInvMap->second;
+                ptg_step_t                  relTrg_step = 0;
                 if (ptg->getPathStepForDist(relTrg_k, relTrg_d, relTrg_step))
                 {
                     // Add direct path to target, and keep a copy of its value:

--- a/mrpt_path_planning_core/src/algos/bestTrajectory.cpp
+++ b/mrpt_path_planning_core/src/algos/bestTrajectory.cpp
@@ -39,9 +39,8 @@ bool mpp::bestTrajectory(
         ptg->updateNavDynamicState(newDyn);
 
         // Inverse map of relative pose:
-        int    ptg_k;
-        double ptg_norm_dist;
-        if (!ptg->inverseMap_WS2TP(relPose.x, relPose.y, ptg_k, ptg_norm_dist))
+        const auto invMap = ptg->inverseMap_WS2TP(relPose.x, relPose.y);
+        if (!invMap.has_value())
         {
             if (logger)
             {
@@ -52,6 +51,8 @@ bool mpp::bestTrajectory(
             // Out of PTG range. Cannot do anything here.
             continue;
         }
+        const int    ptg_k         = invMap->first;
+        const double ptg_norm_dist = invMap->second;
 
         const double ptg_dist = ptg_norm_dist * ptg->getRefDistance();
 

--- a/mrpt_path_planning_core/src/algos/refine_trajectory.cpp
+++ b/mrpt_path_planning_core/src/algos/refine_trajectory.cpp
@@ -49,16 +49,13 @@ void mpp::refine_trajectory(
         // Should never happen, except in buggy callers:
         if (deltaNodes.x == 0 && deltaNodes.y == 0) continue;
 
-        int                   newK        = -1;
-        normalized_distance_t newNormDist = 0;
-
-        const bool ok = ptg->inverseMap_WS2TP(
-            deltaNodes.x, deltaNodes.y, newK, newNormDist, ptg_tolerance_dist);
-        if (!ok)
+        const auto invMap = ptg->inverseMap_WS2TP(
+            deltaNodes.x, deltaNodes.y, ptg_tolerance_dist);
+        if (!invMap.has_value())
         {
             std::stringstream ss;
             ss << "Assert failed: ptg->inverseMap_WS2TP() => returned "
-                  "ok=false. More info:\n";
+                  "nullopt. More info:\n";
             ss << " - PTG: " << ptg->getDescription() << "\n";
             ss << " - deltaNodes: " << deltaNodes.asString() << "\n";
             ss << " - edge: " << edge.asString() << "\n";
@@ -69,10 +66,13 @@ void mpp::refine_trajectory(
         }
         else
         {
+            const int                   newK        = invMap->first;
+            const normalized_distance_t newNormDist = invMap->second;
             distance_t newDist = newNormDist * ptg->getRefDistance();
 
             uint32_t   newPtgStep = 0;
-            const bool stepOk = ptg->getPathStepForDist(newK, newDist, newPtgStep);
+            const bool stepOk =
+                ptg->getPathStepForDist(newK, newDist, newPtgStep);
             if (!stepOk)
             {
                 // The distance returned by inverseMap_WS2TP() (normalized

--- a/mrpt_path_planning_core/src/algos/render_tree.cpp
+++ b/mrpt_path_planning_core/src/algos/render_tree.cpp
@@ -6,26 +6,26 @@
 
 #include <mpp/algos/render_tree.h>
 #include <mpp/algos/render_vehicle.h>
-#include <mrpt/opengl/CArrow.h>
-#include <mrpt/opengl/CDisk.h>
-#include <mrpt/opengl/CGridPlaneXY.h>
-#include <mrpt/opengl/COpenGLScene.h>
-#include <mrpt/opengl/CPointCloud.h>
-#include <mrpt/opengl/CSetOfLines.h>
-#include <mrpt/opengl/CSetOfObjects.h>
-#include <mrpt/opengl/CText3D.h>
-#include <mrpt/opengl/stock_objects.h>
+#include <mrpt/viz/CArrow.h>
+#include <mrpt/viz/CDisk.h>
+#include <mrpt/viz/CGridPlaneXY.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/CSetOfLines.h>
+#include <mrpt/viz/CSetOfObjects.h>
+#include <mrpt/viz/CText3D.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/stock_objects.h>
 
 using namespace mpp;
 
 auto mpp::render_tree(
     const MotionPrimitivesTreeSE2& tree, const PlannerInput& pi,
-    const RenderOptions& ro) -> std::shared_ptr<mrpt::opengl::CSetOfObjects>
+    const RenderOptions& ro) -> std::shared_ptr<mrpt::viz::CSetOfObjects>
 {
-    using mrpt::opengl::stock_objects::CornerXYZ;
-    using mrpt::opengl::stock_objects::CornerXYZSimple;
+    using mrpt::viz::stock_objects::CornerXYZ;
+    using mrpt::viz::stock_objects::CornerXYZSimple;
 
-    auto ret = mrpt::opengl::CSetOfObjects::Create();
+    auto ret = mrpt::viz::CSetOfObjects::Create();
     ret->setName("render_tree");
     auto& scene = *ret;
 
@@ -53,7 +53,7 @@ auto mpp::render_tree(
     };
 
     // Build a model of the vehicle shape:
-    mrpt::opengl::CSetOfLines gl_veh_shape;
+    mrpt::viz::CSetOfLines gl_veh_shape;
 
     double xyzcorners_scale;
     {
@@ -85,7 +85,7 @@ auto mpp::render_tree(
                 gridSpacing = 1.0;
         }
 
-        auto obj = mrpt::opengl::CGridPlaneXY::Create(
+        auto obj = mrpt::viz::CGridPlaneXY::Create(
             pi.worldBboxMin.x, pi.worldBboxMax.x, pi.worldBboxMin.y,
             pi.worldBboxMax.y, 0 /*z*/, gridSpacing);
         obj->setColor_u8(ro.color_ground_xy_grid);
@@ -160,7 +160,7 @@ auto mpp::render_tree(
     // The starting pose vehicle shape must be inserted independently, because
     // the rest are edges and we draw the END pose of each edge:
     {
-        auto vehShape  = mrpt::opengl::CSetOfLines::Create(gl_veh_shape);
+        auto vehShape  = mrpt::viz::CSetOfLines::Create(gl_veh_shape);
         auto shapePose = mrpt::math::TPose3D(pi.stateStart.pose);
         shapePose.z += ro.vehicle_shape_z;
         vehShape->setPose(poseHeightT(shapePose));
@@ -211,7 +211,7 @@ auto mpp::render_tree(
             // Insert vehicle shapes along optimal path:
             if (isBestPathAndDrawShape)
             {
-                auto vehShape = mrpt::opengl::CSetOfLines::Create(gl_veh_shape);
+                auto vehShape  = mrpt::viz::CSetOfLines::Create(gl_veh_shape);
                 auto shapePose = mrpt::math::TPose3D(poseNode);
                 shapePose.z += ro.vehicle_shape_z;
                 vehShape->setPose(poseHeightT(shapePose));
@@ -222,7 +222,7 @@ auto mpp::render_tree(
                 // Draw twist:
                 if (node.vel.vx != 0 || node.vel.vy != 0)
                 {
-                    auto glLinVel = mrpt::opengl::CArrow::Create();
+                    auto glLinVel = mrpt::viz::CArrow::Create();
                     glLinVel->setArrowEnds(
                         0, 0, 0, node.vel.vx * ro.linVelScale,
                         node.vel.vy * ro.linVelScale, .0);
@@ -236,7 +236,7 @@ auto mpp::render_tree(
 
                 if (node.vel.omega != 0)
                 {
-                    auto glAngVel = mrpt::opengl::CArrow::Create();
+                    auto glAngVel = mrpt::viz::CArrow::Create();
                     glAngVel->setArrowEnds(
                         0, 0, 0, 0, 0, node.vel.omega * ro.angVelScale);
                     glAngVel->setSmallRadius(ro.twistArrowsRadius);
@@ -253,7 +253,7 @@ auto mpp::render_tree(
         if (etp && !etp->interpolatedPath.empty())
         {
             // Create the path shape, in relative coords to the parent node:
-            auto obj = mrpt::opengl::CSetOfLines::Create();
+            auto obj = mrpt::viz::CSetOfLines::Create();
             obj->setPose(poseHeight(mrpt::poses::CPose3D(poseParent)));
 
             // Use stored interpolated path to avoid having to update PTG's
@@ -290,19 +290,18 @@ auto mpp::render_tree(
 
             if (ro.showEdgeCosts && obj->getLineWidth() > 0)
             {
-                auto objLb = mrpt::opengl::CText3D::Create();
+                auto objLb = mrpt::viz::CText3D::Create();
 
                 // Place the label by the midpoint of the path:
                 const auto relPose = ip.rbegin()->second;
 
                 objLb->setPose(obj->getPose() + relPose);
                 objLb->setScale(ro.edgeCostLabelSize);
-                objLb->setString(
-                    mrpt::format(
-                        "c=%.02f d=%.02f", etp->cost,
-                        etp->ptgDist != std::numeric_limits<double>::max()
-                            ? etp->ptgDist
-                            : .0));
+                objLb->setString(mrpt::format(
+                    "c=%.02f d=%.02f", etp->cost,
+                    etp->ptgDist != std::numeric_limits<double>::max()
+                        ? etp->ptgDist
+                        : .0));
                 scene.insert(objLb);
             }
 
@@ -325,7 +324,7 @@ auto mpp::render_tree(
     {
         for (const auto& os : pi.obstacles)
         {
-            auto obj = mrpt::opengl::CPointCloud::Create();
+            auto obj = mrpt::viz::CPointCloud::Create();
 
             const auto obs = os->obstacles();
 
@@ -342,8 +341,7 @@ auto mpp::render_tree(
     if (ro.draw_obstacles && ro.local_obs_from_nearest_pose &&
         ro.x_nearest_pose)
     {
-        mrpt::opengl::CPointCloud::Ptr obj =
-            mrpt::opengl::CPointCloud::Create();
+        mrpt::viz::CPointCloud::Ptr obj = mrpt::viz::CPointCloud::Create();
 
         obj->loadFromPointsMap(ro.local_obs_from_nearest_pose.value());
         obj->setPose(*ro.x_nearest_pose);
@@ -375,7 +373,7 @@ auto mpp::render_tree(
     }
     else if (pi.stateGoal.state.isPoint())
     {
-        auto obj = mrpt::opengl::CDisk::Create();
+        auto obj = mrpt::viz::CDisk::Create();
         obj->setDiskRadius(xyzcorners_scale * 1.5, xyzcorners_scale * 1.25);
         obj->setName("GOAL");
         obj->enableShowName();
@@ -383,16 +381,13 @@ auto mpp::render_tree(
         obj->setLocation(mrpt::math::TPoint3D(pi.stateGoal.state.point()));
         scene.insert(obj);
     }
-    else
-    {
-        THROW_EXCEPTION("Unknown type for goal.state");
-    }
+    else { THROW_EXCEPTION("Unknown type for goal.state"); }
 
     // Log msg:
     if (!ro.log_msg.empty())
     {
         auto gl_txt =
-            mrpt::opengl::CText3D::Create(ro.log_msg, "sans", ro.log_msg_scale);
+            mrpt::viz::CText3D::Create(ro.log_msg, "sans", ro.log_msg_scale);
         gl_txt->setLocation(ro.log_msg_position);
         scene.insert(gl_txt);
     }

--- a/mrpt_path_planning_core/src/algos/render_vehicle.cpp
+++ b/mrpt_path_planning_core/src/algos/render_vehicle.cpp
@@ -5,13 +5,13 @@
  * ------------------------------------------------------------------------- */
 
 #include <mpp/algos/render_vehicle.h>
-#include <mrpt/opengl/CSetOfLines.h>
+#include <mrpt/viz/CSetOfLines.h>
 
 using namespace mpp;
 
 /** Generates a polygon for the vehicle shape */
 auto mpp::render_vehicle(
-    const RobotShape& rs, mrpt::opengl::CSetOfLines& outPolygon,
+    const RobotShape& rs, mrpt::viz::CSetOfLines& outPolygon,
     const RenderVehicleParams& rvp) -> RenderVehicleExtraResults
 {
     RenderVehicleExtraResults res;
@@ -48,10 +48,7 @@ auto mpp::render_vehicle(
 
         mrpt::keep_max(res.maxVehicleShapeRadius, R);
     }
-    else
-    {
-        THROW_EXCEPTION("Invalid vehicle shape variant<> type.");
-    }
+    else { THROW_EXCEPTION("Invalid vehicle shape variant<> type."); }
 
     return res;
 }

--- a/mrpt_path_planning_core/src/data/TrajectoriesAndRobotShape.cpp
+++ b/mrpt_path_planning_core/src/data/TrajectoriesAndRobotShape.cpp
@@ -35,7 +35,7 @@ void TrajectoriesAndRobotShape::initFromConfigFile(
         for (size_t i = 0; i < xs.size(); i++)
         {
             poly.emplace_back(xs[i], ys[i]);
-            robShape.AddVertex(xs[i], ys[i]);
+            robShape.add_vertex(xs[i], ys[i]);
         }
     }
 

--- a/mrpt_path_planning_core/src/data/Waypoints.cpp
+++ b/mrpt_path_planning_core/src/data/Waypoints.cpp
@@ -8,9 +8,9 @@
    +------------------------------------------------------------------------+ */
 
 #include <mpp/data/Waypoints.h>
-#include <mrpt/opengl/CArrow.h>
-#include <mrpt/opengl/CDisk.h>
-#include <mrpt/opengl/CSetOfObjects.h>
+#include <mrpt/viz/CArrow.h>
+#include <mrpt/viz/CDisk.h>
+#include <mrpt/viz/CSetOfObjects.h>
 
 using namespace mpp;
 
@@ -165,14 +165,13 @@ WaypointsRenderingParams::WaypointsRenderingParams()
 }
 
 void WaypointSequence::getAsOpenglVisualization(
-    mrpt::opengl::CSetOfObjects&    obj,
-    const WaypointsRenderingParams& params) const
+    mrpt::viz::CSetOfObjects& obj, const WaypointsRenderingParams& params) const
 {
     obj.clear();
     unsigned int idx = 0;
     for (const auto& p : waypoints)
     {
-        auto gl_pt = mrpt::opengl::CDisk::Create(
+        auto gl_pt = mrpt::viz::CDisk::Create(
             p.allowSkip ? params.outter_radius
                         : params.outter_radius_non_skippable,
             p.allowSkip ? params.inner_radius
@@ -189,8 +188,10 @@ void WaypointSequence::getAsOpenglVisualization(
 
         if (p.targetHeading.has_value())
         {
-            auto o = mrpt::opengl::CArrow::Create(
-                0, 0, 0, params.heading_arrow_len, 0.0f, 0.0f);
+            auto o = mrpt::viz::CArrow::Create(
+                mrpt::math::TPoint3Df{0, 0, 0},
+                mrpt::math::TPoint3Df{
+                    static_cast<float>(params.heading_arrow_len), 0, 0});
             o->setPose(mrpt::poses::CPose3D(
                 p.target.x, p.target.y, 0.02, p.targetHeading.value(), 0, 0));
             obj.insert(o);
@@ -200,8 +201,7 @@ void WaypointSequence::getAsOpenglVisualization(
 }
 
 void WaypointStatusSequence::getAsOpenglVisualization(
-    mrpt::opengl::CSetOfObjects&    obj,
-    const WaypointsRenderingParams& params) const
+    mrpt::viz::CSetOfObjects& obj, const WaypointsRenderingParams& params) const
 {
     obj.clear();
     {
@@ -210,7 +210,7 @@ void WaypointStatusSequence::getAsOpenglVisualization(
         {
             const bool is_cur_goal = (int(idx) == waypoint_index_current_goal);
 
-            mrpt::opengl::CDisk::Ptr gl_pt = mrpt::opengl::CDisk::Create(
+            mrpt::viz::CDisk::Ptr gl_pt = mrpt::viz::CDisk::Create(
                 p.reached ? params.outter_radius_reached
                           : (p.allowSkip ? params.outter_radius
                                          : params.outter_radius_non_skippable),
@@ -233,8 +233,10 @@ void WaypointStatusSequence::getAsOpenglVisualization(
 
             if (p.targetHeading.has_value())
             {
-                auto o = mrpt::opengl::CArrow::Create(
-                    0, 0, 0, params.heading_arrow_len, 0.0f, 0.0f);
+                auto o = mrpt::viz::CArrow::Create(
+                    mrpt::math::TPoint3Df{0, 0, 0},
+                    mrpt::math::TPoint3Df{
+                        static_cast<float>(params.heading_arrow_len), 0, 0});
                 o->setPose(mrpt::poses::CPose3D(
                     p.target.x, p.target.y, 0.02, p.targetHeading.value(), 0,
                     0));
@@ -247,9 +249,12 @@ void WaypointStatusSequence::getAsOpenglVisualization(
 
 mrpt::containers::yaml WaypointSequence::asYAML() const
 {
-    auto n = mrpt::containers::yaml::Sequence();
+    mrpt::containers::yaml n = mrpt::containers::yaml::Sequence({});
 
-    for (const auto& wp : waypoints) n.asSequence().emplace_back(wp.asYAML());
+    for (const auto& wp : waypoints)
+    {
+        n.asSequence().emplace_back(wp.asYAML().node());
+    }
 
     return n;
 }

--- a/mrpt_path_planning_core/src/ptgs/DiffDriveCollisionGridBased.cpp
+++ b/mrpt_path_planning_core/src/ptgs/DiffDriveCollisionGridBased.cpp
@@ -17,6 +17,8 @@
 #include <mrpt/system/CTicTac.h>
 
 #include <iostream>
+#include <optional>
+#include <utility>
 
 using namespace mpp::ptg;
 using mrpt::d2f;
@@ -467,8 +469,9 @@ bool DiffDriveCollisionGridBased::CCollisionGrid::loadFromFile(
     }
 }
 
-bool DiffDriveCollisionGridBased::inverseMap_WS2TP(
-    double x, double y, int& out_k, double& out_d, double tolerance_dist) const
+std::optional<std::pair<int, double>>
+    DiffDriveCollisionGridBased::inverseMap_WS2TP(
+        double x, double y, double tolerance_dist) const
 {
     using mrpt::square;
 
@@ -522,7 +525,7 @@ bool DiffDriveCollisionGridBased::inverseMap_WS2TP(
     // Try to find a closest point to the paths:
     // ----------------------------------------------
     int   selected_k    = -1;
-    float selected_d    = 0;
+    float selected_d    = 0.0f;
     float selected_dist = std::numeric_limits<float>::max();
 
     if (at_least_one)  // Otherwise, don't even lose time checking...
@@ -550,9 +553,12 @@ bool DiffDriveCollisionGridBased::inverseMap_WS2TP(
 
     if (selected_k != -1)
     {
-        out_k = selected_k;
-        out_d = selected_d / refDistance;
-        return (selected_dist <= square(tolerance_dist));
+        const double out_d = selected_d / refDistance;
+        if (selected_dist <= square(tolerance_dist))
+        {
+            return std::make_pair(selected_k, out_d);
+        }
+        return std::nullopt;
     }
 
     // If not found, compute an extrapolation:
@@ -580,15 +586,16 @@ bool DiffDriveCollisionGridBased::inverseMap_WS2TP(
 
     selected_d = std::sqrt(selected_d);
 
-    out_k = selected_k;
-    out_d = selected_d / refDistance;
-
-    // If the target dist. > refDistance, then it's normal that we had to
-    // extrapolate.
-    // Otherwise, it may actually mean that the target is not reachable by this
-    // set of paths:
+    // If the target dist. > refDistance, it's normal that we had to
+    // extrapolate. Otherwise, the target may not be reachable by this set of
+    // paths:
     const float target_dist = std::sqrt(x * x + y * y);
-    return (target_dist > target_dist);
+    if (target_dist > refDistance)
+    {
+        return std::make_pair(
+            selected_k, static_cast<double>(selected_d / refDistance));
+    }
+    return std::nullopt;
 }
 
 void DiffDriveCollisionGridBased::setRefDistance(const double refDist)
@@ -678,7 +685,7 @@ void DiffDriveCollisionGridBased::internal_initialize(
         const int    grid_cy_max = m_collisionGrid.getSizeY() - 1;
         const double half_cell   = m_collisionGrid.getResolution() * 0.5;
 
-        const size_t                      nVerts = m_robotShape.verticesCount();
+        const size_t                      nVerts = m_robotShape.size();
         std::vector<mrpt::math::TPoint2D> transf_shape(
             nVerts);  // The robot shape at each location
 
@@ -703,11 +710,11 @@ void DiffDriveCollisionGridBased::internal_initialize(
                 for (size_t m = 0; m < nVerts; m++)
                 {
                     transf_shape[m].x =
-                        p.x + cos(p.phi) * m_robotShape.GetVertex_x(m) -
-                        sin(p.phi) * m_robotShape.GetVertex_y(m);
+                        p.x + cos(p.phi) * m_robotShape.get_vertex_x(m) -
+                        sin(p.phi) * m_robotShape.get_vertex_y(m);
                     transf_shape[m].y =
-                        p.y + sin(p.phi) * m_robotShape.GetVertex_x(m) +
-                        cos(p.phi) * m_robotShape.GetVertex_y(m);
+                        p.y + sin(p.phi) * m_robotShape.get_vertex_x(m) +
+                        cos(p.phi) * m_robotShape.get_vertex_y(m);
                     mrpt::keep_max(bb_max.x, transf_shape[m].x);
                     mrpt::keep_max(bb_max.y, transf_shape[m].y);
                     mrpt::keep_min(bb_min.x, transf_shape[m].x);

--- a/mrpt_path_planning_core/src/ptgs/DiffDrive_C.cpp
+++ b/mrpt_path_planning_core/src/ptgs/DiffDrive_C.cpp
@@ -11,6 +11,9 @@
 #include <mrpt/math/wrap2pi.h>
 #include <mrpt/serialization/CArchive.h>
 
+#include <optional>
+#include <utility>
+
 using namespace mrpt;
 using namespace mrpt::nav;
 using namespace mrpt::system;
@@ -85,11 +88,12 @@ bool DiffDrive_C::PTG_IsIntoDomain(
     return true;
 }
 
-bool DiffDrive_C::inverseMap_WS2TP(
-    double x, double y, int& k_out, double& d_out,
-    [[maybe_unused]] double tolerance_dist) const
+std::optional<std::pair<int, double>> DiffDrive_C::inverseMap_WS2TP(
+    double x, double y, [[maybe_unused]] double tolerance_dist) const
 {
-    bool is_exact = true;
+    int    k_out;
+    double d_out;
+    bool   is_exact = true;
     if (y != 0)
     {
         double       R    = (x * x + y * y) / (2 * y);
@@ -99,20 +103,16 @@ bool DiffDrive_C::inverseMap_WS2TP(
 
         if (K > 0)
         {
-            if (y > 0)
-                theta = atan2((double)x, fabs(R) - y);
-            else
-                theta = atan2((double)x, y + fabs(R));
+            if (y > 0) { theta = atan2((double)x, fabs(R) - y); }
+            else { theta = atan2((double)x, y + fabs(R)); }
         }
         else
         {
-            if (y > 0)
-                theta = atan2(-(double)x, fabs(R) - y);
-            else
-                theta = atan2(-(double)x, y + fabs(R));
+            if (y > 0) { theta = atan2(-(double)x, fabs(R) - y); }
+            else { theta = atan2(-(double)x, y + fabs(R)); }
         }
 
-        // Arc length must be possitive [0,2*pi]
+        // Arc length must be positive [0,2*pi]
         mrpt::math::wrapTo2PiInPlace(theta);
 
         // Distance thru arc:
@@ -150,7 +150,8 @@ bool DiffDrive_C::inverseMap_WS2TP(
     ASSERT_GE_(k_out, 0);
     ASSERT_LT_(k_out, m_alphaValuesCount);
 
-    return is_exact;
+    if (!is_exact) { return std::nullopt; }
+    return std::make_pair(k_out, d_out);
 }
 
 void DiffDrive_C::loadDefaultParams()

--- a/mrpt_path_planning_core/src/ptgs/HolonomicBlend.cpp
+++ b/mrpt_path_planning_core/src/ptgs/HolonomicBlend.cpp
@@ -22,6 +22,8 @@
 #include <mrpt/system/CTimeLogger.h>
 
 #include <iostream>  // debug only, remove!
+#include <optional>
+#include <utility>
 
 using namespace mrpt::nav;
 using namespace mpp::ptg;
@@ -168,15 +170,9 @@ double HolonomicBlend::calc_trans_distance_t_below_Tramp(
             const double int_t = sqrt(a) * (t * t) * 0.5;
             return int_t;  // Definite integral [0,t]
         }
-        else
-        {
-            return calc_trans_distance_t_below_Tramp_abc(t, a, b, c);
-        }
+        else { return calc_trans_distance_t_below_Tramp_abc(t, a, b, c); }
     }
-    else
-    {
-        return std::sqrt(c) * t;
-    }
+    else { return std::sqrt(c) * t; }
 }
 
 void HolonomicBlend::onNewNavDynamicState()
@@ -298,12 +294,16 @@ void    HolonomicBlend::serializeTo(mrpt::serialization::CArchive& out) const
     out << expr_V << expr_W << expr_T_ramp;
 }
 
-bool HolonomicBlend::inverseMap_WS2TP(
-    double x, double y, int& out_k, double& out_d,
-    [[maybe_unused]] double tolerance_dist) const
+std::optional<std::pair<int, double>> HolonomicBlend::inverseMap_WS2TP(
+    double x, double y, [[maybe_unused]] double tolerance_dist) const
 {
-    double dummy_T_ramp;
-    return inverseMap_WS2TP_with_Tramp(x, y, out_k, out_d, dummy_T_ramp);
+    int        out_k;
+    double     out_d;
+    double     dummy_T_ramp;
+    const bool ok =
+        inverseMap_WS2TP_with_Tramp(x, y, out_k, out_d, dummy_T_ramp);
+    if (!ok) { return std::nullopt; }
+    return std::make_pair(out_k, out_d);
 }
 
 bool HolonomicBlend::inverseMap_WS2TP_with_Tramp(
@@ -478,17 +478,12 @@ bool HolonomicBlend::inverseMap_WS2TP_with_Tramp(
 
         return true;
     }
-    else
-    {
-        return false;
-    }
+    else { return false; }
 }
 
 bool HolonomicBlend::PTG_IsIntoDomain(double x, double y) const
 {
-    int    k;
-    double d;
-    return inverseMap_WS2TP(x, y, k, d);
+    return inverseMap_WS2TP(x, y).has_value();
 }
 
 void HolonomicBlend::internal_deinitialize()
@@ -775,10 +770,7 @@ void HolonomicBlend::updateTPObstacleSingle(
             roots[0]      = (-d + sqrt(discr)) / (2 * c);
             roots[1]      = (-d - sqrt(discr)) / (2 * c);
         }
-        else
-        {
-            num_real_sols = 0;
-        }
+        else { num_real_sols = 0; }
     }
 
     for (int i = 0; i < num_real_sols; i++)

--- a/mrpt_path_planning_core/wip-experimental/TPS_RRTstar.cpp
+++ b/mrpt_path_planning_core/wip-experimental/TPS_RRTstar.cpp
@@ -11,8 +11,8 @@
 #include <mpp/algos/within_bbox.h>
 #include <mrpt/maps/COccupancyGridMap2D.h>
 #include <mrpt/maps/CSimplePointsMap.h>
-#include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/random/RandomGenerators.h>
+#include <mrpt/viz/Scene.h>
 
 #include <iostream>
 
@@ -493,12 +493,11 @@ PlannerOutput TPS_RRTstar::plan(const PlannerInput& in)
         {
             RenderOptions ro;
             ro.highlight_path_to_node_id = newNodeId;
-            mrpt::opengl::COpenGLScene scene;
+            mrpt::viz::Scene scene;
             scene.insert(render_tree(tree, in, ro));
-            scene.saveToFile(
-                mrpt::format(
-                    "debug_rrtstar_%05u.3Dscene",
-                    static_cast<unsigned int>(rrtIter)));
+            scene.saveToFile(mrpt::format(
+                "debug_rrtstar_%05u.3Dscene",
+                static_cast<unsigned int>(rrtIter)));
         }
 
     }  // for each rrtIter
@@ -645,13 +644,12 @@ TPS_RRTstar::draw_pose_return_t TPS_RRTstar::draw_random_tps(
             // Bias towards goal:
             const auto relGoalPose =
                 p.pi_.stateGoal.asSE2KinState().pose - node.pose;
-            int    relTrg_k;
-            double relTrg_d;
-            if (ptg->inverseMap_WS2TP(
-                    relGoalPose.x, relGoalPose.y, relTrg_k, relTrg_d))
+            const auto trgInvMap =
+                ptg->inverseMap_WS2TP(relGoalPose.x, relGoalPose.y);
+            if (trgInvMap.has_value())
             {
                 // valid:
-                trajIdx = relTrg_k;
+                trajIdx = trgInvMap->first;
             }
         }
 


### PR DESCRIPTION
Part of the MOLA-wide MRPT 3.x port.

Re-ported after the upstream core/apps/viz repository split: per-module `mrpt_*` packages, namespaced `mrpt::mrpt_*` targets, and the `opengl` to `viz` move.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added footprint-aware cost evaluation using robot shapes.
  * Updated visualization support for the current MRPT framework.

* **Improvements**
  * Migrated path-planner and self-driving simulator command-line options to a consistent interface.
  * Optional configuration settings are applied only when provided, while required inputs remain validated.
  * Improved compatibility across supported simulator event-handling variants.
  * Path-to-trajectory mapping now reports unavailable mappings explicitly and no longer extrapolates beyond simulated paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->